### PR TITLE
Simplify config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ using `go run mage.go updateLibs`.
 
 ### Running the filter in an Envoy process
 
-In order to run the coraza-proxy-wasm we need to spin up an envoy configuration including this as the filter config:
+In order to run the coraza-proxy-wasm we need to spin up an envoy configuration including this as the filter config
 
 ```yaml
     ...

--- a/config.go
+++ b/config.go
@@ -12,7 +12,7 @@ import (
 
 // pluginConfiguration is a type to represent an example configuration for this wasm plugin.
 type pluginConfiguration struct {
-	rules string
+	rules []string
 }
 
 func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
@@ -28,8 +28,10 @@ func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
 	}
 
 	jsonData := gjson.ParseBytes(data)
-	rules := jsonData.Get("rules")
-	config.rules = rules.String()
-
+	config.rules = []string{}
+	jsonData.Get("rules").ForEach(func(_, value gjson.Result) bool {
+		config.rules = append(config.rules, value.String())
+		return true
+	})
 	return config, nil
 }

--- a/config.go
+++ b/config.go
@@ -5,23 +5,14 @@ package main
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
-	"io"
-	"io/fs"
-	"strings"
 
 	"github.com/tidwall/gjson"
 )
 
-type rule struct {
-	inline  string
-	include string
-}
-
 // pluginConfiguration is a type to represent an example configuration for this wasm plugin.
 type pluginConfiguration struct {
-	rules []rule
+	rules string
 }
 
 func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
@@ -38,89 +29,7 @@ func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
 
 	jsonData := gjson.ParseBytes(data)
 	rules := jsonData.Get("rules")
-	rules.ForEach(func(_, value gjson.Result) bool {
-		if inline := value.Get("inline"); inline.Exists() {
-			config.rules = append(config.rules, rule{inline: inline.String()})
-			return true
-		} else if include := value.Get("include"); include.Exists() {
-			config.rules = append(config.rules, rule{include: include.String()})
-			return true
-		} else {
-			return false
-		}
-	})
+	config.rules = rules.String()
 
 	return config, nil
-}
-
-func resolveIncludes(rs []rule, crsRules fs.FS) (string, error) {
-	if len(rs) == 0 {
-		return "", nil
-	}
-
-	srs := strings.Builder{}
-	defer srs.Reset()
-	for _, r := range rs {
-		switch {
-		case r.inline != "":
-			srs.WriteString(strings.TrimSpace(r.inline))
-
-		case r.include != "":
-			if r.include == "OWASP_CRS" {
-				ors := strings.Builder{}
-
-				err := fs.WalkDir(crsRules, ".", func(path string, d fs.DirEntry, err error) error {
-					if err != nil {
-						return err
-					}
-
-					if d.IsDir() {
-						return nil
-					}
-
-					if !strings.HasPrefix(path, "REQUEST-") && !strings.HasPrefix(path, "RESPONSE-") {
-						return nil
-					}
-
-					f, err := crsRules.Open(path)
-					if err != nil {
-						return fmt.Errorf("failed to open embedded rule %q: %s", path, err.Error())
-					}
-
-					fc, err := io.ReadAll(f)
-					f.Close()
-					if err != nil {
-						return fmt.Errorf("failed to read embedded rule file %q: %s", path, err.Error())
-					}
-
-					_, err = ors.Write(bytes.TrimSpace(fc))
-					return err
-				})
-				if err != nil {
-					return "", fmt.Errorf("failed to walk embedded rules: %s", err.Error())
-				}
-
-				owaspCRSContent := strings.TrimSpace(ors.String())
-				ors.Reset()
-				srs.WriteString(owaspCRSContent)
-			} else {
-				f, err := crsRules.Open(r.include[len("OWASP_CRS_"):] + ".conf")
-				if err != nil {
-					return "", fmt.Errorf("failed to open embedded rule %q: %s", r.include, err.Error())
-				}
-				content, err := io.ReadAll(f)
-				f.Close()
-				if err != nil {
-					return "", fmt.Errorf("failed to read embedded rule file: %s", err.Error())
-				}
-				content = bytes.TrimSpace(content)
-				srs.Write(content)
-			}
-		default:
-			return "", errors.New("empty rule")
-		}
-		srs.WriteString("\n")
-	}
-
-	return strings.TrimSpace(srs.String()), nil
 }

--- a/example/envoy-config.yaml
+++ b/example/envoy-config.yaml
@@ -42,11 +42,11 @@ static_resources:
                           value: |
                             {
                               "rules": [
-                                {"inline": "Include coraza-demo.conf"},
-                                {"inline": "Include crs-setup-demo.conf"},
-                                {"inline": "SecDebugLogLevel 3"},
-                                {"inline": "Include crs/*.conf"},
-                                {"inline": "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""}
+                                "Include coraza-demo.conf",
+                                "Include crs-setup-demo.conf",
+                                "SecDebugLogLevel 3",
+                                "Include crs/*.conf",
+                                "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
                               ]
                             }
                         vm_config:
@@ -62,8 +62,8 @@ static_resources:
   clusters:
     - name: local_server
       connect_timeout: 6000s
-      type: strict_dns
-      lb_policy: round_robin
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
       load_assignment:
         cluster_name: local_server
         endpoints:

--- a/ftw/envoy-config.yaml
+++ b/ftw/envoy-config.yaml
@@ -37,10 +37,10 @@ static_resources:
                           value: |
                             {
                               "rules": [
-                                {"inline": "Include coraza.conf-recommended.conf"},
-                                {"inline": "Include ftw-config.conf"},
-                                {"inline": "Include crs-setup.conf.example"},
-                                {"inline": "Include crs/*.conf"}
+                                "Include coraza.conf-recommended.conf",
+                                "Include ftw-config.conf",
+                                "Include crs-setup.conf.example",
+                                "Include crs/*.conf"
                               ]
                             }
                         vm_config:
@@ -56,8 +56,8 @@ static_resources:
   clusters:
     - name: local_server
       connect_timeout: 6000s
-      type: strict_dns
-      lb_policy: round_robin
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
       load_assignment:
         cluster_name: local_server
         endpoints:

--- a/internal/operators/rx.go
+++ b/internal/operators/rx.go
@@ -22,7 +22,7 @@ var _ rules.Operator = (*rx)(nil)
 
 func (o *rx) Init(options rules.OperatorOptions) error {
 	data := options.Arguments
-	// fmt.Println(data)
+
 	if data == `(?:\$(?:\((?:\(.*\)|.*)\)|\{.*})|\/\w*\[!?.+\]|[<>]\(.*\))` {
 		o.debug = true
 		fmt.Println("enabling rx debug!")

--- a/main.go
+++ b/main.go
@@ -68,27 +68,12 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 		WithDebugLogger(&debugLogger{}).
 		WithRequestBodyAccess(coraza.NewRequestBodyConfig().
 			WithLimit(1024 * 1024 * 1024).
-			// TinyGo compilation will prevent buffering request body to files anyways, so this is
-			// effectively no-op but make clear our expectations.
+			// TinyGo compilation will prevent buffering request body to files anyways.
 			// TODO(anuraaga): Make this configurable in plugin configuration.
 			WithInMemoryLimit(1024 * 1024 * 1024)).
 		WithRootFS(root)
 
-	crs, err := fs.Sub(crs, "custom_rules")
-	if err != nil {
-		proxywasm.LogCriticalf("failed to access CRS filesystem: %v", err)
-		return types.OnPluginStartStatusFailed
-	}
-
-	rules, err := resolveIncludes(config.rules, crs)
-	if err != nil {
-		proxywasm.LogCriticalf("failed to load embedded rules: %v", err)
-		return types.OnPluginStartStatusFailed
-	}
-
-	conf = conf.WithDirectives(rules)
-
-	waf, err := coraza.NewWAF(conf)
+	waf, err := coraza.NewWAF(conf.WithDirectives(config.rules))
 	if err != nil {
 		proxywasm.LogCriticalf("failed to parse rules: %v", err)
 		return types.OnPluginStartStatusFailed

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"embed"
 	"io/fs"
 	"strconv"
+	"strings"
 
 	"github.com/corazawaf/coraza/v3"
 	ctypes "github.com/corazawaf/coraza/v3/types"
@@ -73,7 +74,7 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 			WithInMemoryLimit(1024 * 1024 * 1024)).
 		WithRootFS(root)
 
-	waf, err := coraza.NewWAF(conf.WithDirectives(config.rules))
+	waf, err := coraza.NewWAF(conf.WithDirectives(strings.Join(config.rules, "\n")))
 	if err != nil {
 		proxywasm.LogCriticalf("failed to parse rules: %v", err)
 		return types.OnPluginStartStatusFailed

--- a/main_test.go
+++ b/main_test.go
@@ -287,7 +287,7 @@ SecRuleEngine On\nSecResponseBodyAccess On\nSecRule RESPONSE_BODY \"@contains he
 				if inlineRules := strings.TrimSpace(tt.inlineRules); inlineRules != "" {
 					conf = fmt.Sprintf(`
 					{ 
-						"rules": [ { "inline": "%s" } ]
+						"rules": "%s"
 					}	
 				`, inlineRules)
 				}
@@ -581,7 +581,7 @@ func TestLogError(t *testing.T) {
 			t.Run(fmt.Sprintf("severity %d", tt.severity), func(t *testing.T) {
 				conf := fmt.Sprintf(`
 {
-	"rules" : [{"inline": "SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""}]
+	"rules" : "SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""
 }
 `, tt.severity)
 
@@ -611,7 +611,7 @@ func TestParseCRS(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{ "rules": [ {"inline": "Include ftw-config.conf\nInclude coraza.conf-recommended.conf\nInclude crs-setup.conf.example\nInclude crs/*.conf"} ] }`))
+			WithPluginConfiguration([]byte(`{ "rules": [ "Include ftw-config.conf", "Include coraza.conf-recommended.conf", "Include crs-setup.conf.example", "Include crs/*.conf" ] }`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()
@@ -681,7 +681,7 @@ SecRuleEngine On\nSecRule REQUEST_URI \"@streq /hello\" \"id:101,phase:4,t:lower
 
 			t.Run(tt.name, func(t *testing.T) {
 				conf := fmt.Sprintf(`
-					{ "rules": [ {"inline": "%s"} ] }
+					{ "rules": "%s" }
 				`, strings.TrimSpace(tt.rules))
 				opt := proxytest.
 					NewEmulatorOption().

--- a/main_test.go
+++ b/main_test.go
@@ -285,11 +285,7 @@ SecRuleEngine On\nSecResponseBodyAccess On\nSecRule RESPONSE_BODY \"@contains he
 			t.Run(tt.name, func(t *testing.T) {
 				conf := `{}`
 				if inlineRules := strings.TrimSpace(tt.inlineRules); inlineRules != "" {
-					conf = fmt.Sprintf(`
-					{ 
-						"rules": "%s"
-					}	
-				`, inlineRules)
+					conf = fmt.Sprintf(`{"rules": ["%s"]}`, inlineRules)
 				}
 				opt := proxytest.
 					NewEmulatorOption().
@@ -581,7 +577,7 @@ func TestLogError(t *testing.T) {
 			t.Run(fmt.Sprintf("severity %d", tt.severity), func(t *testing.T) {
 				conf := fmt.Sprintf(`
 {
-	"rules" : "SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""
+	"rules" : ["SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""]
 }
 `, tt.severity)
 
@@ -681,7 +677,7 @@ SecRuleEngine On\nSecRule REQUEST_URI \"@streq /hello\" \"id:101,phase:4,t:lower
 
 			t.Run(tt.name, func(t *testing.T) {
 				conf := fmt.Sprintf(`
-					{ "rules": "%s" }
+					{ "rules": ["%s"] }
 				`, strings.TrimSpace(tt.rules))
 				opt := proxytest.
 					NewEmulatorOption().

--- a/testdata/fake_crs/REQUEST-911.conf
+++ b/testdata/fake_crs/REQUEST-911.conf
@@ -1,1 +1,0 @@
-# just a comment


### PR DESCRIPTION
This PR changes the config to simplify it and let users to load it directly. One thing we must consider here is:
a. folder structure of `rules` is now part of the public API (maybe we should add a check to not to break it)
b. we should be able to validate includes in standalone mode (i.e. without running them in the extension).