### PR TITLE
Split TinyGo docker build into wasi-libc and tinygo

### DIFF
--- a/.github/workflows/buildtools-tinygo.yaml
+++ b/.github/workflows/buildtools-tinygo.yaml
@@ -39,6 +39,15 @@ jobs:
       - uses: docker/build-push-action@v3
         with:
           context: buildtools/tinygo
+          file: buildtools/tinygo/wasi-libc.Dockerfile
+          push: false
+          platforms: linux/amd64
+          tags: ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo-wasi-libc:main
+          load: true
+
+      - uses: docker/build-push-action@v3
+        with:
+          context: buildtools/tinygo
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/buildtools-tinygo.yaml
+++ b/.github/workflows/buildtools-tinygo.yaml
@@ -19,6 +19,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v3
 
@@ -40,15 +45,15 @@ jobs:
         with:
           context: buildtools/tinygo
           file: buildtools/tinygo/wasi-libc.Dockerfile
-          push: false
+          push: true
           platforms: linux/amd64
-          tags: ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo-wasi-libc:main
-          load: true
+          tags: localhost:5000/buildtools-tinygo-wasi-libc:main
 
       - uses: docker/build-push-action@v3
         with:
           context: buildtools/tinygo
           push: ${{ github.event_name != 'pull_request' }}
           platforms: linux/amd64,linux/arm64
+          build-args: WASI_LIBC_IMAGE=localhost:5000/buildtools-tinygo-wasi-libc:main
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/buildtools-tinygo.yaml
+++ b/.github/workflows/buildtools-tinygo.yaml
@@ -35,6 +35,8 @@ jobs:
 
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
 
       - uses: docker/metadata-action@v4
         id: meta

--- a/buildtools/tinygo/Dockerfile
+++ b/buildtools/tinygo/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright 2022 The OWASP Coraza contributors
 # SPDX-License-Identifier: Apache-2.0
 
+ARG WASI_LIBC_IMAGE
 FROM --platform=linux/amd64 ${WASI_LIBC_IMAGE:-ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo-wasi-libc:main} AS wasi-libc
 
 FROM ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-wasi-sdk:main

--- a/buildtools/tinygo/Dockerfile
+++ b/buildtools/tinygo/Dockerfile
@@ -1,7 +1,9 @@
 # Copyright 2022 The OWASP Coraza contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/anuraaga/coraza-wasm-filter/buildtools-wasi-sdk:main
+FROM --platform=linux/amd64 ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo-wasi-libc:main AS wasi-libc
+
+FROM ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-wasi-sdk:main
 
 ARG TARGETARCH
 
@@ -10,11 +12,8 @@ RUN curl -L https://go.dev/dl/go1.19.1.linux-${TARGETARCH:-amd64}.tar.gz | tar -
 ENV PATH /go/bin:/root/go/bin:$PATH
 ENV GOROOT /go
 
-RUN apt-get install -y libclang-14-dev wabt binaryen git
+RUN apt-get install -y libclang-14-dev wabt binaryen
 
-# https://github.com/tinygo-org/tinygo/commit/9e4e182615cd80303c564f95020e0c3bd10af64a
-RUN git clone --shallow-submodules --recursive https://github.com/tinygo-org/tinygo --branch dev
+COPY --from=wasi-libc /tinygo /tinygo
 WORKDIR /tinygo
-RUN git reset --hard 9e4e182615cd80303c564f95020e0c3bd10af64a
 RUN go install
-RUN make wasi-libc

--- a/buildtools/tinygo/Dockerfile
+++ b/buildtools/tinygo/Dockerfile
@@ -1,7 +1,8 @@
 # Copyright 2022 The OWASP Coraza contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=linux/amd64 ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo-wasi-libc:main AS wasi-libc
+ARG WASI_LIBC_IMAGE
+FROM --platform=linux/amd64 ${WASI_LIBC_IMAGE:-ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo-wasi-libc:main} AS wasi-libc
 
 FROM ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-wasi-sdk:main
 

--- a/buildtools/tinygo/wasi-libc.Dockerfile
+++ b/buildtools/tinygo/wasi-libc.Dockerfile
@@ -1,0 +1,13 @@
+# Copyright 2022 The OWASP Coraza contributors
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-wasi-sdk:main
+
+RUN apt-get install -y git
+
+# https://github.com/tinygo-org/tinygo/commit/9e4e182615cd80303c564f95020e0c3bd10af64a
+RUN git clone https://github.com/tinygo-org/tinygo --branch dev
+WORKDIR /tinygo
+RUN git reset --hard 9e4e182615cd80303c564f95020e0c3bd10af64a
+RUN git submodule update --init lib/wasi-libc
+RUN make wasi-libc


### PR DESCRIPTION
Former doesn't need to be multiarch