### PR TITLE
chore: makes nightly check to run on ci.yaml change.

### DIFF
--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -3,12 +3,13 @@ on:
   pull_request:
     paths:
       - ".github/workflows/nightly-coraza-check.yaml"
+      - ".github/workflows/ci.yaml"
   schedule:
     - cron: "0 4 * * *"
 
 env:
-  GO_VERSION: 1.18
-  TINYGO_VERSION: 0.25.0
+  GO_VERSION: 1.19
+  TINYGO_VERSION: 0.26.0
   WABT_VERSION: 1.0.29
 
 jobs:


### PR DESCRIPTION
Usually we change tinygo or go version on ci.yaml and forget to keep track of the change in the nightly.