### PR TITLE
Clarifies the :path pseudo-header includes query params

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,7 +133,9 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 	// and its request properties, but they may not be true of other proxies implementing
 	// proxy-wasm.
 
-	path, err := proxywasm.GetHttpRequestHeader(":path")
+	// Note the pseudo-header :path includes the query.
+	// See https://httpwg.org/specs/rfc9113.html#rfc.section.8.3.1
+	uri, err := proxywasm.GetHttpRequestHeader(":path")
 	if err != nil {
 		proxywasm.LogCriticalf("failed to get :path: %v", err)
 		return types.ActionContinue
@@ -154,7 +156,7 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 
 	ctx.httpProtocol = string(protocol)
 
-	tx.ProcessURI(path, method, ctx.httpProtocol)
+	tx.ProcessURI(uri, method, ctx.httpProtocol)
 
 	hs, err := proxywasm.GetHttpRequestHeaders()
 	if err != nil {

--- a/main_test.go
+++ b/main_test.go
@@ -24,7 +24,7 @@ func checkTXMetric(t *testing.T, host proxytest.HostEmulator, expectedCounter in
 
 func TestLifecycle(t *testing.T) {
 	reqHdrs := [][2]string{
-		{":path", "/hello"},
+		{":path", "/hello?name=panda"},
 		{":method", "GET"},
 		{":authority", "localhost"},
 		{"User-Agent", "gotest"},
@@ -69,7 +69,7 @@ SecRuleEngine On\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lower
 		{
 			name: "url denied",
 			inlineRules: `
-SecRuleEngine On\nSecRule REQUEST_URI \"@streq /hello\" \"id:101,phase:1,t:lowercase,deny\"
+SecRuleEngine On\nSecRule REQUEST_URI \"@streq /hello?name=panda\" \"id:101,phase:1,t:lowercase,deny\"
 `,
 			requestHdrsAction:  types.ActionPause,
 			requestBodyAction:  types.ActionContinue,


### PR DESCRIPTION
This changes the variable name for the uri to represent what it is even if the HTTP pseudo header name is :path. This helps with porting as a mistake is easier otherwise.
