### PR TITLE
Add back TinyGo docker build

### DIFF
--- a/.github/workflows/buildtools-tinygo.yaml
+++ b/.github/workflows/buildtools-tinygo.yaml
@@ -1,0 +1,61 @@
+name: Build TinyGo
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - buildtools/tinygo/**
+      - .github/workflows/buildtools-tinygo.yaml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - buildtools/tinygo/**
+      - .github/workflows/buildtools-tinygo.yaml
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-qemu-action@v2
+      - uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: network=host
+
+      - uses: docker/metadata-action@v4
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}/buildtools-tinygo
+
+      - uses: docker/build-push-action@v3
+        with:
+          context: buildtools/tinygo
+          file: buildtools/tinygo/wasi-libc.Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: localhost:5000/buildtools-tinygo-wasi-libc:main
+
+      - uses: docker/build-push-action@v3
+        with:
+          context: buildtools/tinygo
+          push: ${{ github.event_name != 'pull_request' }}
+          platforms: linux/amd64,linux/arm64
+          build-args: WASI_LIBC_IMAGE=localhost:5000/buildtools-tinygo-wasi-libc:main
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/buildtools/tinygo/Dockerfile
+++ b/buildtools/tinygo/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2022 The OWASP Coraza contributors
+# SPDX-License-Identifier: Apache-2.0
+
+ARG WASI_LIBC_IMAGE
+FROM --platform=linux/amd64 ${WASI_LIBC_IMAGE:-ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo-wasi-libc:main} AS wasi-libc
+
+FROM ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-wasi-sdk:main
+
+ARG TARGETARCH
+
+RUN curl -L https://go.dev/dl/go1.19.2.linux-${TARGETARCH:-amd64}.tar.gz | tar -xz
+
+ENV PATH /go/bin:/root/go/bin:$PATH
+ENV GOROOT /go
+
+RUN apt-get update && apt-get install -y libclang-15-dev wabt binaryen
+
+COPY --from=wasi-libc /tinygo /tinygo
+WORKDIR /tinygo
+RUN go install

--- a/buildtools/tinygo/wasi-libc.Dockerfile
+++ b/buildtools/tinygo/wasi-libc.Dockerfile
@@ -1,0 +1,13 @@
+# Copyright 2022 The OWASP Coraza contributors
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-wasi-sdk:main
+
+RUN apt-get install -y git
+
+# https://github.com/tinygo-org/tinygo/pull/3245
+RUN git clone https://github.com/anuraaga/tinygo --branch customgc
+WORKDIR /tinygo
+RUN git fetch origin && git reset --hard 8e62159e36217975bdf27cfb4271c2ad2d252441
+RUN git submodule update --init lib/wasi-libc
+RUN make wasi-libc


### PR DESCRIPTION
This builds TinyGo with https://github.com/tinygo-org/tinygo/pull/3245. Ideally we stick to released TinyGo, but this change affects us dramatically.