### PR TITLE
Rename gc package for initialization ordering

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/corazawaf/coraza-proxy-wasm
 go 1.19
 
 require (
-	github.com/corazawaf/coraza/v3 v3.0.0-20221025015745-5b0dfa270c3a
+	github.com/corazawaf/coraza/v3 v3.0.0-20221028022635-635fad46ea34
 	github.com/magefile/mage v1.14.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.19.1-0.20220922045757-132ee0a06ac2

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/corazawaf/coraza/v3 v3.0.0-20221025015745-5b0dfa270c3a h1:CpC23lHjesOjuhFC6rHXSyr5IOIRut/zjJmno+gQ1uk=
-github.com/corazawaf/coraza/v3 v3.0.0-20221025015745-5b0dfa270c3a/go.mod h1:+ypLPFkX5j1GwKi+rqRZ57W3lSHReBdeVLh0o8qirI4=
+github.com/corazawaf/coraza/v3 v3.0.0-20221028022635-635fad46ea34 h1:kh70ZE9Df1xhebrqhwkCqV0bKkr/mjXwyDEYPBmgEJ4=
+github.com/corazawaf/coraza/v3 v3.0.0-20221028022635-635fad46ea34/go.mod h1:+ypLPFkX5j1GwKi+rqRZ57W3lSHReBdeVLh0o8qirI4=
 github.com/corazawaf/libinjection-go v0.1.1 h1:N/SMuy9Q4wPL72pU/OsoYjIIjfvUbsVwHf8A3tWMLKg=
 github.com/corazawaf/libinjection-go v0.1.1/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/init_tinygo.go
+++ b/init_tinygo.go
@@ -5,7 +5,7 @@
 
 package main
 
-import _ "github.com/corazawaf/coraza-proxy-wasm/internal/gc"
+import _ "github.com/corazawaf/coraza-proxy-wasm/internal/agc"
 
 // #cgo LDFLAGS: lib/libinjection.a lib/libre2.a lib/libcre2.a lib/libc++.a lib/libc++abi.a lib/libclang_rt.builtins-wasm32.a lib/libaho_corasick.a lib/libmimalloc.a
 import "C"

--- a/internal/agc/doc.go
+++ b/internal/agc/doc.go
@@ -1,0 +1,15 @@
+// Copyright The OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+// Package agc is a custom gargabe gollector for TinyGo. The main difference is instead of taking
+// ownership of the entire process heap, it uses malloc to allocate blocks for the GC to then
+// assign to allocated objects.
+//
+// Unfortunately, we must rely on a package init() method for initializing the heap because we
+// cannot override TinyGo's initHeap function that normally does it. This means initialization
+// order matters, this package should be the first package to be initialized - any packages
+// initialized before cannot allocate memory. For that reason, we have named this agc instead
+// of gc.
+//
+// Currently, only one block can be allocated meaning this has a fixed-size heap.
+package agc

--- a/internal/agc/gc_conservative.go
+++ b/internal/agc/gc_conservative.go
@@ -6,7 +6,7 @@
 // Copied from https://github.com/tinygo-org/tinygo/blob/3dbc4d52105f4209ece1332f0272f293745ac0bf/src/runtime/gc_conservative.go
 // with modifications to use malloc for underlying memory storage.
 
-package gc
+package agc
 
 // This memory manager is a textbook mark/sweep implementation, heavily inspired
 // by the MicroPython garbage collector.

--- a/internal/agc/gc_globals.go
+++ b/internal/agc/gc_globals.go
@@ -6,7 +6,7 @@
 // Copied from https://github.com/tinygo-org/tinygo/blob/3dbc4d52105f4209ece1332f0272f293745ac0bf/src/runtime/gc_globals.go
 // with private start symbols redefined.
 
-package gc
+package agc
 
 import "unsafe"
 

--- a/internal/agc/gc_stack_portable.go
+++ b/internal/agc/gc_stack_portable.go
@@ -6,7 +6,7 @@
 // Copied from https://github.com/tinygo-org/tinygo/blob/3dbc4d52105f4209ece1332f0272f293745ac0bf/src/runtime/gc_stack_portable.go
 // with go:linkname used to override functions in the runtime package.
 
-package gc
+package agc
 
 import (
 	"unsafe"

--- a/internal/agc/mem.go
+++ b/internal/agc/mem.go
@@ -3,7 +3,7 @@
 
 //go:build tinygo
 
-package gc
+package agc
 
 import "unsafe"
 

--- a/internal/bodyprocessors/xml.go
+++ b/internal/bodyprocessors/xml.go
@@ -10,29 +10,28 @@ package bodyprocessors
 
 import (
 	"encoding/xml"
+	"github.com/corazawaf/coraza/v3/rules"
 	"io"
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/bodyprocessors"
-	"github.com/corazawaf/coraza/v3/collection"
-	"github.com/corazawaf/coraza/v3/types/variables"
 )
 
 type xmlBodyProcessor struct {
 }
 
-func (*xmlBodyProcessor) ProcessRequest(reader io.Reader, collections []collection.Collection, _ bodyprocessors.Options) error {
+func (*xmlBodyProcessor) ProcessRequest(reader io.Reader, vars rules.TransactionVariables, _ bodyprocessors.Options) error {
 	values, contents, err := readXML(reader)
 	if err != nil {
 		return err
 	}
-	col := collections[variables.RequestXML].(*collection.Map)
+	col := vars.RequestXML()
 	col.Set("//@*", values)
 	col.Set("/*", contents)
 	return nil
 }
 
-func (*xmlBodyProcessor) ProcessResponse(io.Reader, []collection.Collection, bodyprocessors.Options) error {
+func (*xmlBodyProcessor) ProcessResponse(io.Reader, rules.TransactionVariables, bodyprocessors.Options) error {
 	return nil
 }
 

--- a/internal/bodyprocessors/xml.go
+++ b/internal/bodyprocessors/xml.go
@@ -10,11 +10,11 @@ package bodyprocessors
 
 import (
 	"encoding/xml"
-	"github.com/corazawaf/coraza/v3/rules"
 	"io"
 	"strings"
 
 	"github.com/corazawaf/coraza/v3/bodyprocessors"
+	"github.com/corazawaf/coraza/v3/rules"
 )
 
 type xmlBodyProcessor struct {

--- a/internal/gc/doc.go
+++ b/internal/gc/doc.go
@@ -1,9 +1,0 @@
-// Copyright The OWASP Coraza contributors
-// SPDX-License-Identifier: Apache-2.0
-
-// Package gc is a custom gargabe gollector for TinyGo. The main difference is instead of taking
-// ownership of the entire process heap, it uses malloc to allocate blocks for the GC to then
-// assign to allocated objects.
-//
-// Currently, only one block can be allocated meaning this has a fixed-size heap.
-package gc


### PR DESCRIPTION
Something about https://github.com/corazawaf/coraza/commit/635fad46ea34169ee11ed1cfee198692fb29ff5e caused allocations to happen in initialization before the gc package can setup the heap. For normal code this is fine so it would be too much of a restriction to ensure coraza never does this and we need to handle it here.

Go executes init functions for imports in alphabetical order it seems (I tried putting the import explicitly above the others to no effect). Currently the only option seems to be renaming the package - as a followup to the change in TinyGo to allow custom malloc I may try to improve this, but that would be a more intrusive change and so hopefully we can be decoupled even if we need this trick.

Perhaps we can just name this GC implementation the "anuraaga gc" and then the name makes sense anyways...