### PR TITLE
feat: adds configuration mapping.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ configuration:
     "@type": "type.googleapis.com/google.protobuf.StringValue"
     value: |
     {
-        "rules": [ "SecDebugLogLevel 5", "SecRuleEngine On", "Include crs/*.conf" ]
+        "rules": [ "SecDebugLogLevel 5", "SecRuleEngine On", "Include @owasp_crs/*.conf" ]
     }
 ```
 
@@ -99,7 +99,7 @@ configuration:
     "@type": "type.googleapis.com/google.protobuf.StringValue"
     value: |
     {
-        "rules": [ "SecDebugLogLevel 5", "SecRuleEngine On", "Include crs/REQUEST-901-INITIALIZATION.conf" ]
+        "rules": [ "SecDebugLogLevel 5", "SecRuleEngine On", "Include @owasp_crs/REQUEST-901-INITIALIZATION.conf" ]
     }
 ```
 
@@ -115,7 +115,7 @@ Take a look at its config file [ftw.yml](./ftw/ftw.yml) for details about tests 
 
 ## Example: Spinning up the coraza-wasm-filter for manual tests
 
-Once the filter is built, via the commands `mage runExample` and `mage teardownExample` you can spin up and tear down the test environment. Envoy with the coraza-wasm filter will be reachable at `localhost:8080`. The filter is configured with the CRS loaded working in Anomaly Scoring mode. For details and locally tweaking the configuration refer to [coraza-demo.conf](./rules/coraza-demo.conf) and [crs-setup-demo.conf](./rules/crs-setup-demo.conf).
+Once the filter is built, via the commands `mage runExample` and `mage teardownExample` you can spin up and tear down the test environment. Envoy with the coraza-wasm filter will be reachable at `localhost:8080`. The filter is configured with the CRS loaded working in Anomaly Scoring mode. For details and locally tweaking the configuration refer to [@demo-conf](./rules/coraza-demo.conf) and [@crs-setup-demo-conf](./rules/crs-setup-demo.conf).
 In order to monitor envoy logs while performing requests you can run:
 
 - Envoy logs: `docker-compose -f ./example/docker-compose.yml logs -f envoy-logs`.

--- a/config_test.go
+++ b/config_test.go
@@ -48,7 +48,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 			}
 			`,
 			expectConfig: pluginConfiguration{
-				rules: []string{"SecRuleEngine On", "Include crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""},
+				rules: []string{"SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""},
 			},
 		},
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -44,7 +44,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 			name: "inline many entries",
 			config: `
 			{ 
-				"rules": ["SecRuleEngine On", "Include @owasp_@owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""]
+				"rules": ["SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""]
 			}
 			`,
 			expectConfig: pluginConfiguration{

--- a/config_test.go
+++ b/config_test.go
@@ -44,7 +44,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 			name: "inline many entries",
 			config: `
 			{ 
-				"rules": ["SecRuleEngine On", "Include crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""]
+				"rules": ["SecRuleEngine On", "Include @owasp_@owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""]
 			}
 			`,
 			expectConfig: pluginConfiguration{

--- a/example/envoy-config.yaml
+++ b/example/envoy-config.yaml
@@ -42,10 +42,10 @@ static_resources:
                           value: |
                             {
                               "rules": [
-                                "Include coraza-demo.conf",
-                                "Include crs-setup-demo.conf",
+                                "Include @demo-conf",
+                                "Include @crs-setup-demo-conf",
                                 "SecDebugLogLevel 3",
-                                "Include crs/*.conf",
+                                "Include @owasp_crs/*.conf",
                                 "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
                               ]
                             }

--- a/fs.go
+++ b/fs.go
@@ -1,3 +1,6 @@
+// Copyright The OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/fs.go
+++ b/fs.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+)
+
+type embedFS interface {
+	fs.FS
+	ReadDir(name string) ([]fs.DirEntry, error)
+	ReadFile(name string) ([]byte, error)
+}
+
+type rulesFS struct {
+	fs           embedFS
+	filesMapping map[string]string
+	dirsMapping  map[string]string
+}
+
+const pathSeparator = string(os.PathSeparator)
+
+func (r rulesFS) Open(name string) (fs.File, error) {
+	if strings.Contains(name, pathSeparator) {
+		// is not in root, hence we can do dir mapping
+		for a, dst := range r.dirsMapping {
+			prefix := a + pathSeparator
+			if strings.HasPrefix(name, prefix) {
+				return r.fs.Open(path.Join(dst, name[len(prefix):]))
+			}
+		}
+	}
+
+	for a, dst := range r.filesMapping {
+		if a == name {
+			return r.fs.Open(dst)
+		}
+	}
+
+	return r.fs.Open(name)
+}
+
+func (r rulesFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	for a, dst := range r.dirsMapping {
+		if a == name {
+			return r.fs.ReadDir(dst)
+		}
+
+		prefix := a + pathSeparator
+		if strings.HasPrefix(name, prefix) {
+			return r.fs.ReadDir(path.Join(dst, name[len(prefix):]))
+		}
+	}
+	return r.fs.ReadDir(name)
+}
+
+func (r rulesFS) ReadFile(name string) ([]byte, error) {
+	for a, dst := range r.filesMapping {
+		if a == name {
+			return r.fs.ReadFile(dst)
+		}
+	}
+
+	return r.fs.ReadFile(name)
+}

--- a/ftw/envoy-config.yaml
+++ b/ftw/envoy-config.yaml
@@ -37,10 +37,10 @@ static_resources:
                           value: |
                             {
                               "rules": [
-                                "Include coraza.conf-recommended.conf",
-                                "Include ftw-config.conf",
+                                "Include @recommended-conf",
+                                "Include @ftw-conf",
                                 "Include crs-setup.conf.example",
-                                "Include crs/*.conf"
+                                "Include @owasp_crs/*.conf"
                               ]
                             }
                         vm_config:

--- a/main.go
+++ b/main.go
@@ -65,7 +65,7 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 	root, _ := fs.Sub(crs, "rules")
 
 	root = &rulesFS{
-		root.(embedFS),
+		root,
 		map[string]string{
 			"@recommended-conf":    "coraza.conf-recommended.conf",
 			"@demo-conf":           "coraza-demo.conf",

--- a/main.go
+++ b/main.go
@@ -64,6 +64,19 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 
 	root, _ := fs.Sub(crs, "rules")
 
+	root = &rulesFS{
+		root.(embedFS),
+		map[string]string{
+			"@recommended-conf":    "coraza.conf-recommended.conf",
+			"@demo-conf":           "coraza-demo.conf",
+			"@crs-setup-demo-conf": "crs-setup-demo.conf",
+			"@ftw-conf":            "ftw-config.conf",
+		},
+		map[string]string{
+			"@owasp_crs": "crs",
+		},
+	}
+
 	// First we initialize our waf and our seclang parser
 	conf := coraza.NewWAFConfig().
 		WithErrorLogger(logError).

--- a/main_test.go
+++ b/main_test.go
@@ -663,7 +663,7 @@ func TestParseCRS(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{ "rules": [ "Include ftw-config.conf", "Include coraza.conf-recommended.conf", "Include crs-setup.conf.example", "Include crs/*.conf" ] }`))
+			WithPluginConfiguration([]byte(`{ "rules": [ "Include @ftw-conf", "Include @recommended-conf", "Include crs-setup.conf.example", "Include crs/*.conf" ] }`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()

--- a/main_test.go
+++ b/main_test.go
@@ -663,7 +663,7 @@ func TestParseCRS(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{ "rules": [ "Include @ftw-conf", "Include @recommended-conf", "Include crs-setup.conf.example", "Include crs/*.conf" ] }`))
+			WithPluginConfiguration([]byte(`{ "rules": [ "Include @ftw-conf", "Include @recommended-conf", "Include crs-setup.conf.example", "Include @owasp_crs/*.conf" ] }`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()


### PR DESCRIPTION
This feature allows users to use @recommended-conf instead of 'coraza.conf-recommended', etc. as a way to abstract the location of this configurations and allowing users to mount volumes with config in the future without collision.