### PR TITLE
adds @crs-setup-conf to configuration mapping

### DIFF
--- a/ftw/envoy-config.yaml
+++ b/ftw/envoy-config.yaml
@@ -39,7 +39,7 @@ static_resources:
                               "rules": [
                                 "Include @recommended-conf",
                                 "Include @ftw-conf",
-                                "Include crs-setup.conf.example",
+                                "Include @crs-setup-conf-example",
                                 "Include @owasp_crs/*.conf"
                               ]
                             }

--- a/ftw/envoy-config.yaml
+++ b/ftw/envoy-config.yaml
@@ -39,7 +39,7 @@ static_resources:
                               "rules": [
                                 "Include @recommended-conf",
                                 "Include @ftw-conf",
-                                "Include @crs-setup-conf-example",
+                                "Include @crs-setup-conf",
                                 "Include @owasp_crs/*.conf"
                               ]
                             }

--- a/main.go
+++ b/main.go
@@ -67,10 +67,11 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 	root = &rulesFS{
 		root,
 		map[string]string{
-			"@recommended-conf":    "coraza.conf-recommended.conf",
-			"@demo-conf":           "coraza-demo.conf",
-			"@crs-setup-demo-conf": "crs-setup-demo.conf",
-			"@ftw-conf":            "ftw-config.conf",
+			"@recommended-conf":       "coraza.conf-recommended.conf",
+			"@demo-conf":              "coraza-demo.conf",
+			"@crs-setup-demo-conf":    "crs-setup-demo.conf",
+			"@ftw-conf":               "ftw-config.conf",
+			"@crs-setup-conf-example": "crs-setup.conf.example",
 		},
 		map[string]string{
 			"@owasp_crs": "crs",

--- a/main_test.go
+++ b/main_test.go
@@ -690,7 +690,7 @@ func TestParseCRS(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{ "rules": [ "Include @ftw-conf", "Include @recommended-conf", "Include @crs-setup-conf-example", "Include @owasp_crs/*.conf" ] }`))
+			WithPluginConfiguration([]byte(`{ "rules": [ "Include @ftw-conf", "Include @recommended-conf", "Include @crs-setup-conf", "Include @owasp_crs/*.conf" ] }`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()

--- a/main_test.go
+++ b/main_test.go
@@ -690,7 +690,7 @@ func TestParseCRS(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{ "rules": [ "Include @ftw-conf", "Include @recommended-conf", "Include crs-setup.conf.example", "Include @owasp_crs/*.conf" ] }`))
+			WithPluginConfiguration([]byte(`{ "rules": [ "Include @ftw-conf", "Include @recommended-conf", "Include @crs-setup-conf-example", "Include @owasp_crs/*.conf" ] }`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()

--- a/rules/fs.go
+++ b/rules/fs.go
@@ -22,11 +22,11 @@ func init() {
 	FS = &rulesFS{
 		rules,
 		map[string]string{
-			"@recommended-conf":       "coraza.conf-recommended.conf",
-			"@demo-conf":              "coraza-demo.conf",
-			"@crs-setup-demo-conf":    "crs-setup-demo.conf",
-			"@ftw-conf":               "ftw-config.conf",
-			"@crs-setup-conf-example": "crs-setup.conf.example",
+			"@recommended-conf":    "coraza.conf-recommended.conf",
+			"@demo-conf":           "coraza-demo.conf",
+			"@crs-setup-demo-conf": "crs-setup-demo.conf",
+			"@ftw-conf":            "ftw-config.conf",
+			"@crs-setup-conf":      "crs-setup.conf.example",
 		},
 		map[string]string{
 			"@owasp_crs": "crs",

--- a/rules/fs_test.go
+++ b/rules/fs_test.go
@@ -21,7 +21,7 @@ var (
 	}
 
 	files = []string{
-		"Include @crs-setup-conf-example",
+		"Include @crs-setup-conf",
 		"Include @recommended-conf",
 		"Include @ftw-conf",
 		"Include @owasp_crs/*.conf",


### PR DESCRIPTION
Small PR that follows https://github.com/corazawaf/coraza-proxy-wasm/pull/79#discussion_r1022610150, adds `@crs-setup-conf-example` keyword. 