### PR TITLE
Expose the rules filesystem for offline rule validation

### DIFF
--- a/rules/fs.go
+++ b/rules/fs.go
@@ -1,13 +1,37 @@
 // Copyright The OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package rules
 
 import (
+	"embed"
 	"fmt"
 	"io/fs"
 	"strings"
 )
+
+var (
+	//go:embed crs/* *.conf *.example
+	rules embed.FS
+	// FS is the filesystem that contains the embedded rule set and recommended
+	// configurations
+	FS fs.FS
+)
+
+func init() {
+	FS = &rulesFS{
+		rules,
+		map[string]string{
+			"@recommended-conf":    "coraza.conf-recommended.conf",
+			"@demo-conf":           "coraza-demo.conf",
+			"@crs-setup-demo-conf": "crs-setup-demo.conf",
+			"@ftw-conf":            "ftw-config.conf",
+		},
+		map[string]string{
+			"@owasp_crs": "crs",
+		},
+	}
+}
 
 type rulesFS struct {
 	fs           fs.FS

--- a/rules/fs_test.go
+++ b/rules/fs_test.go
@@ -1,0 +1,64 @@
+// Copyright The OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package rules_test
+
+import (
+	"testing"
+
+	"github.com/corazawaf/coraza/v3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/corazawaf/coraza-proxy-wasm/rules"
+)
+
+var (
+	basic = []string{
+		"SecRuleEngine On",
+		"# comments are ignored",
+		"SecResponseBodyMimeType text/plain text/html text/xml",
+		`SecRule ARGS:id "@eq 0" "id:1, phase:1,deny, status:403,msg:'Invalid id',log,auditlog"`,
+	}
+
+	files = []string{
+		"Include crs-setup.conf.example",
+		"Include @recommended-conf",
+		"Include @ftw-conf",
+		"Include @owasp_crs/*.conf",
+	}
+
+	demo = []string{
+		"Include @demo-conf",
+		"Include @crs-setup-demo-conf",
+	}
+)
+
+func TestRulesFS(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		err  bool
+	}{
+		{"nil", nil, false},
+		{"empty", []string{}, false},
+		{"basic", basic, false},
+		{"files", files, false},
+		{"demo", demo, false},
+		{"invalid-arg", []string{"SecRuleEngine"}, true},            // Missing argument
+		{"invalid-incomplete", []string{"SecRule ARGS:id"}, true},   // Incomplete rule
+		{"invalid-file", []string{"Include unexisting.conf"}, true}, // Include unexisting file
+		{"invalid-alias", []string{"Include @owasp_crs"}, true},     // Invalid alias usage
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := coraza.NewWAFConfig().WithRootFS(rules.FS)
+			for _, r := range tt.in {
+				cfg = cfg.WithDirectives(r)
+			}
+
+			_, err := coraza.NewWAF(cfg)
+			require.Equalf(t, tt.err, err != nil, "failed: %v", err)
+		})
+	}
+}


### PR DESCRIPTION
Today there is no practical way to validate the rules before the extension is loaded. The seclang `parser` package in Coraza is internal, but using it directly is not enough to properly validate a set of rules. Access to the rule filesystem is needed to validate that `Include` directives do not point to unexisting files.

Validating rules beforehand is IMO an important UX topic. Without it, invalid rules would cause the extension to error and not load, and that will only happen at runtime, leaving just some traces in the proxy logs. users may not notice and assume their WAF is running while it's not.

This PR exposes the rules FS so coraza can be loaded as a library with this filesystem, in order to do proper rule validation.
Note that the `fs.go` has been moved to the `rules` package since package `main` is not importable in Go.