### PR TITLE
Expose a method to get a WAF config that uses the embedded FS

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,8 +5,6 @@ package main
 
 import (
 	"bytes"
-	"embed"
-	"io/fs"
 	"strconv"
 	"strings"
 
@@ -17,10 +15,8 @@ import (
 
 	"github.com/corazawaf/coraza-proxy-wasm/internal/bodyprocessors"
 	"github.com/corazawaf/coraza-proxy-wasm/internal/operators"
+	"github.com/corazawaf/coraza-proxy-wasm/rules"
 )
-
-//go:embed rules
-var crs embed.FS
 
 func main() {
 	bodyprocessors.Register()
@@ -62,32 +58,15 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 		return types.OnPluginStartStatusFailed
 	}
 
-	root, _ := fs.Sub(crs, "rules")
-
-	root = &rulesFS{
-		root,
-		map[string]string{
-			"@recommended-conf":    "coraza.conf-recommended.conf",
-			"@demo-conf":           "coraza-demo.conf",
-			"@crs-setup-demo-conf": "crs-setup-demo.conf",
-			"@ftw-conf":            "ftw-config.conf",
-			"@crs-setup-conf":      "crs-setup.conf.example",
-		},
-		map[string]string{
-			"@owasp_crs": "crs",
-		},
-	}
-
 	// First we initialize our waf and our seclang parser
-	conf := coraza.NewWAFConfig().
+	conf := rules.NewEmbeddedRulesConfig().
 		WithErrorLogger(logError).
 		WithDebugLogger(&debugLogger{}).
 		WithRequestBodyAccess(coraza.NewRequestBodyConfig().
 			WithLimit(1024 * 1024 * 1024).
 			// TinyGo compilation will prevent buffering request body to files anyways.
 			// TODO(anuraaga): Make this configurable in plugin configuration.
-			WithInMemoryLimit(1024 * 1024 * 1024)).
-		WithRootFS(root)
+			WithInMemoryLimit(1024 * 1024 * 1024))
 
 	waf, err := coraza.NewWAF(conf.WithDirectives(strings.Join(config.rules, "\n")))
 	if err != nil {

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -1,12 +1,40 @@
 // Copyright The OWASP Coraza contributors
 // SPDX-License-Identifier: Apache-2.0
 
-package main
+package rules
 
 import (
+	"embed"
 	"fmt"
 	"io/fs"
 	"strings"
+
+	"github.com/corazawaf/coraza/v3"
+)
+
+// NewEmbeddedRulesConfig returns a coraza.WAFConfig that uses the embedded filesystem as the source
+// of rules.
+func NewEmbeddedRulesConfig() coraza.WAFConfig {
+	return coraza.NewWAFConfig().WithRootFS(root)
+}
+
+var (
+	//go:embed crs/* *.conf *.example
+	rules embed.FS
+
+	root = &rulesFS{
+		rules,
+		map[string]string{
+			"@recommended-conf":    "coraza.conf-recommended.conf",
+			"@demo-conf":           "coraza-demo.conf",
+			"@crs-setup-demo-conf": "crs-setup-demo.conf",
+			"@ftw-conf":            "ftw-config.conf",
+			"@crs-setup-conf":      "crs-setup.conf.example",
+		},
+		map[string]string{
+			"@owasp_crs": "crs",
+		},
+	}
 )
 
 type rulesFS struct {


### PR DESCRIPTION
This is a follow-up from https://github.com/corazawaf/coraza-proxy-wasm/pull/88#issuecomment-1318284204

The approach of making the plugin type public and letting clients call the lifecycle methods manually has the counterpart that there is no practical way of getting the rule validation errors. The interface methods just return the status, but there are no accessors for the details, in case of failure.

Having a custom `Validate` method is an alternative, but this basically means exposing an API that there were some reservations about.

Instead, we can just expose a method to get a WAFConfig that is already configured to see the embedded rules. I think this method doesn't expose any unreasonable API and does not bring any new semantics (such as validation) to the public methods of this project, while still allowing clients to leverage the validation logic discussed in the linked issue.

WDYT?