### PR TITLE
chore: sets MAX_BODY_SIZE for go-httpbin

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   httpbin:
     image: mccutchen/go-httpbin:v2.5.0
+    environment:
+      - MAX_BODY_SIZE=15728640 # 15 MiB
   chown:
     image: alpine:3.16
     command:


### PR DESCRIPTION
Sets an higher maximum size of request or response bodies (default is [1Mib](https://github.com/mccutchen/go-httpbin)) for testing purposes with big payloads.