### PR TITLE
Switch TinyGo to custom gc fork

### DIFF
--- a/buildtools/tinygo/wasi-libc.Dockerfile
+++ b/buildtools/tinygo/wasi-libc.Dockerfile
@@ -5,8 +5,9 @@ FROM ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-wasi-sdk:main
 
 RUN apt-get install -y git
 
-RUN git clone https://github.com/tinygo-org/tinygo --branch dev
+RUN git clone https://github.com/anuraaga/tinygo --branch custom-gc
 WORKDIR /tinygo
-RUN git fetch origin dev && git reset --hard 4daf4fa0a061e7e3b098a3b2a9d8bf022424c6d3
+# https://github.com/tinygo-org/tinygo/pull/3302
+RUN git fetch origin custom-gc && git reset --hard e27e61ed063c4febd053f3e1637e9f89b012ad1f
 RUN git submodule update --init lib/wasi-libc
 RUN make wasi-libc

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -193,7 +193,7 @@ func Build() error {
 	script := fmt.Sprintf(`
 cd /src && \
 tinygo build -gc=none -opt=2 -o %s -scheduler=none -target=wasi %s`, filepath.Join("build", "mainraw.wasm"), buildTagArg)
-	if err := sh.RunV("docker", "run", "--pull=always", "--rm", "-v", fmt.Sprintf("%s:/src", wd), "ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo:main",
+	if err := sh.RunV("docker", "run", "--pull=always", "--rm", "-v", fmt.Sprintf("%s:/src", wd), "docker pull ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo:sha-eadd078",
 		"bash", "-c", script); err != nil {
 		return err
 	}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -193,7 +193,7 @@ func Build() error {
 	script := fmt.Sprintf(`
 cd /src && \
 tinygo build -gc=none -opt=2 -o %s -scheduler=none -target=wasi %s`, filepath.Join("build", "mainraw.wasm"), buildTagArg)
-	if err := sh.RunV("docker", "run", "--pull=always", "--rm", "-v", fmt.Sprintf("%s:/src", wd), "docker pull ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo:sha-eadd078",
+	if err := sh.RunV("docker", "run", "--pull=always", "--rm", "-v", fmt.Sprintf("%s:/src", wd), "ghcr.io/corazawaf/coraza-proxy-wasm/buildtools-tinygo:sha-eadd078",
 		"bash", "-c", script); err != nil {
 		return err
 	}


### PR DESCRIPTION
While the upstream PR is stalled, it will either be merged or we will need to just continue with a fork, as it's still better than being locked to a reverted commit.