### PR TITLE
chore: upgrades coraza, fixes nightly check

### DIFF
--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Get last commit of coraza
         id: coraza-latest-commit
-        run: echo "::set-output name=value::$(gh api repos/corazawaf/coraza/commits/v3/dev -q .sha)"
+        run: echo "value=$(gh api repos/corazawaf/coraza/commits/v3/dev -q .sha)" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/corazawaf/coraza-proxy-wasm
 go 1.19
 
 require (
-	github.com/corazawaf/coraza/v3 v3.0.0-20221108125006-22f2f33e5863
+	github.com/corazawaf/coraza/v3 v3.0.0-20221206102836-fb52935e8360
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.20.1-0.20221031045735-89d180d022a5
 	github.com/tidwall/gjson v1.14.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/corazawaf/coraza/v3 v3.0.0-20221108125006-22f2f33e5863 h1:9wGp/AV78wZmj73bgJREXc/73OxbhJSOTa4ib3N1dDY=
-github.com/corazawaf/coraza/v3 v3.0.0-20221108125006-22f2f33e5863/go.mod h1:SMJQI/wT4xkDyCPnt6LN3q8bnci/VXhq7IglfW5isOM=
+github.com/corazawaf/coraza/v3 v3.0.0-20221206102836-fb52935e8360 h1:EHXMulKPpYruaaYb4n6OcZOsbWANTvrTLULVS0EgaM8=
+github.com/corazawaf/coraza/v3 v3.0.0-20221206102836-fb52935e8360/go.mod h1:SMJQI/wT4xkDyCPnt6LN3q8bnci/VXhq7IglfW5isOM=
 github.com/corazawaf/libinjection-go v0.1.1 h1:N/SMuy9Q4wPL72pU/OsoYjIIjfvUbsVwHf8A3tWMLKg=
 github.com/corazawaf/libinjection-go v0.1.1/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -164,7 +164,7 @@ func (ctx *httpContext) OnHttpRequestBody(bodySize int, endOfStream bool) types.
 	tx := ctx.tx
 
 	// Do not perform any action related to request body if SecRequestBodyAccess is set to false
-	if !tx.RequestBodyAccessible() {
+	if !tx.IsRequestBodyAccessible() {
 		proxywasm.LogDebug("skipping request body inspection, SecRequestBodyAccess is off.")
 		return types.ActionContinue
 	}
@@ -254,7 +254,7 @@ func (ctx *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types
 	tx := ctx.tx
 
 	// Do not perform any action related to response body if SecResponseBodyAccess is set to false
-	if !tx.ResponseBodyAccessible() {
+	if !tx.IsResponseBodyAccessible() {
 		proxywasm.LogDebug("skipping response body inspection, SecResponseBodyAccess is off.")
 		return types.ActionContinue
 	}


### PR DESCRIPTION
This PR:
- Upgrades Coraza fixing breaking changes that lead to Nightly Check failure
- Updates deprecated `set-output` command following https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples