### PR TITLE
Enables CRS early blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ configuration:
 ```
 
 #### Recommendations using CRS with proxy-wasm
-- In order to mitigate as much as possible malicious requests (or connections open) sent upstream, it is recommended to keep enabled [CRS Early Blocking](https://coreruleset.org/20220302/the-case-for-early-blocking/) feature (SecAction [`900120`](./wasmplugin/rules/crs-setup-demo.conf)).
+- In order to mitigate as much as possible malicious requests (or connections open) sent upstream, it is recommended to keep the [CRS Early Blocking](https://coreruleset.org/20220302/the-case-for-early-blocking/) feature enabled (SecAction [`900120`](./wasmplugin/rules/crs-setup.conf.example)).
 
 ### Running go-ftw (CRS Regression tests)
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ configuration:
     }
 ```
 
+#### Recommendations using CRS with proxy-wasm
+- In order to mitigate as much as possible malicious requests (or connections open) sent upstream, it is recommended to keep enabled [CRS Early Blocking](https://coreruleset.org/20220302/the-case-for-early-blocking/) feature (SecAction [`900120`](./wasmplugin/rules/crs-setup-demo.conf)).
+
 ### Running go-ftw (CRS Regression tests)
 
 The following command runs the [go-ftw](https://github.com/fzipi/go-ftw) test suite against the filter with the CRS fully loaded.

--- a/wasmplugin/rules/crs-setup-demo.conf
+++ b/wasmplugin/rules/crs-setup-demo.conf
@@ -398,13 +398,13 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # does not get evaluated if the request is being blocked early. So when you
 # disabled early blocking again at some point in the future, then new alerts
 # from phase 2 might pop up.
-#SecAction \
-#  "id:900120,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.early_blocking=1"
+SecAction \
+ "id:900120,\
+ phase:1,\
+ nolog,\
+ pass,\
+ t:none,\
+ setvar:tx.early_blocking=1"
 
 
 #

--- a/wasmplugin/rules/crs-setup.conf.example
+++ b/wasmplugin/rules/crs-setup.conf.example
@@ -398,13 +398,13 @@ SecDefaultAction "phase:2,log,auditlog,pass"
 # does not get evaluated if the request is being blocked early. So when you
 # disabled early blocking again at some point in the future, then new alerts
 # from phase 2 might pop up.
-#SecAction \
-#  "id:900120,\
-#  phase:1,\
-#  nolog,\
-#  pass,\
-#  t:none,\
-#  setvar:tx.early_blocking=1"
+SecAction \
+ "id:900120,\
+ phase:1,\
+ nolog,\
+ pass,\
+ t:none,\
+ setvar:tx.early_blocking=1"
 
 
 #


### PR DESCRIPTION
Running the CRS in Anomaly Scoring Mode (default mode), the anomaly score evaluation happens at the end of phase 2 (request body) and phase 4 (response body). Enabling [early blocking](https://coreruleset.org/20220302/the-case-for-early-blocking/), the evaluation will happen also at the end of phase 1 (request header) and phase 3 (response headers).
I think that this feature is really handy for proxy-wasm in order to mitigate malicious payloads sent upstream: the earlier we raise an interruption, the better (See also https://github.com/corazawaf/coraza-proxy-wasm/pull/128).

As a matter of example: CRS rule `913100` is triggered at phase 1 and looks for malicious User-Agents.
Request: `curl -I --user-agent "Grabber/0.1 (X11; U; Linux i686; en-US; rv:1.7)" -H "Host: localhost" -H "Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5" localhost:8080`

**Before (early blocking disabled)**:
The request is just blocked at `http_response_headers` phase, at that time the request already reached upstream.
```
Coraza: Warning. Inbound Anomaly Score Exceeded (Total Score: 5)
wasm log coraza-filter my_vm_id: 2 interrupted, action "deny", phase "http_response_headers"
```

**After (early blocking disabled)**:
The request is blocked at http_request_headers phase, right after the detection. It happens before sending anything upstream.
```
Coraza: Warning. Inbound Anomaly Score Exceeded in phase 1 (Total Score: 5)
wasm log coraza-filter my_vm_id: 2 interrupted, action "deny", phase "http_request_headers"
```