### PR TITLE
address Flattered limits in Coraza

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,16 @@ module github.com/corazawaf/coraza-proxy-wasm
 go 1.19
 
 require (
-	github.com/corazawaf/coraza/v3 v3.0.0-20230110223518-703d29668893
+	github.com/corazawaf/coraza/v3 v3.0.0-20230127084452-d6bafe9f0f92
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.20.1-0.20230115020858-593cf0f7417a
-	github.com/tidwall/gjson v1.14.3
+	github.com/tidwall/gjson v1.14.4
 	github.com/wasilibs/go-aho-corasick v0.2.0
 	github.com/wasilibs/go-re2 v0.0.0-20221219074959-3ec67f9038f0
 )
 
 require (
-	github.com/corazawaf/libinjection-go v0.1.1 // indirect
+	github.com/corazawaf/libinjection-go v0.1.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/magefile/mage v1.14.0 // indirect
@@ -21,7 +21,7 @@ require (
 	github.com/tetratelabs/wazero v1.0.0-pre.7 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	golang.org/x/net v0.1.0 // indirect
+	golang.org/x/net v0.5.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,11 @@
 github.com/corazawaf/coraza/v3 v3.0.0-20230110223518-703d29668893 h1:ARMfbunvqZfXCphuTMiG7RWDBbCOOTRygJbQGJwQMWA=
 github.com/corazawaf/coraza/v3 v3.0.0-20230110223518-703d29668893/go.mod h1:SMJQI/wT4xkDyCPnt6LN3q8bnci/VXhq7IglfW5isOM=
+github.com/corazawaf/coraza/v3 v3.0.0-20230127084452-d6bafe9f0f92 h1:hBLOjJNVq6vJvS4RrNbRkrUVhcq1zQx/fdMw199WrGc=
+github.com/corazawaf/coraza/v3 v3.0.0-20230127084452-d6bafe9f0f92/go.mod h1:dXFswKzaDVm4SsHAyvi12A4yLfg2bVx/myCBkyGALGU=
 github.com/corazawaf/libinjection-go v0.1.1 h1:N/SMuy9Q4wPL72pU/OsoYjIIjfvUbsVwHf8A3tWMLKg=
 github.com/corazawaf/libinjection-go v0.1.1/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
+github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
+github.com/corazawaf/libinjection-go v0.1.2/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -29,6 +33,8 @@ github.com/tetratelabs/wazero v1.0.0-pre.7 h1:WI5N14XxoXw+ZWhcjSazJ6rEowhJbH/x8h
 github.com/tetratelabs/wazero v1.0.0-pre.7/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
 github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
+github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
 github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
@@ -41,6 +47,8 @@ github.com/wasilibs/go-re2 v0.0.0-20221219074959-3ec67f9038f0/go.mod h1:9YbcVrla
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
 golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
+golang.org/x/net v0.5.0 h1:GyT4nK/YDHSqa1c4753ouYCDajOYKTja9Xb/OHtgvSw=
+golang.org/x/net v0.5.0/go.mod h1:DivGGAXEgPSlEBzxGzZI+ZLohi+xUj054jfeKui00ws=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/corazawaf/coraza/v3 v3.0.0-20230110223518-703d29668893 h1:ARMfbunvqZfXCphuTMiG7RWDBbCOOTRygJbQGJwQMWA=
-github.com/corazawaf/coraza/v3 v3.0.0-20230110223518-703d29668893/go.mod h1:SMJQI/wT4xkDyCPnt6LN3q8bnci/VXhq7IglfW5isOM=
 github.com/corazawaf/coraza/v3 v3.0.0-20230127084452-d6bafe9f0f92 h1:hBLOjJNVq6vJvS4RrNbRkrUVhcq1zQx/fdMw199WrGc=
 github.com/corazawaf/coraza/v3 v3.0.0-20230127084452-d6bafe9f0f92/go.mod h1:dXFswKzaDVm4SsHAyvi12A4yLfg2bVx/myCBkyGALGU=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
@@ -29,8 +27,6 @@ github.com/tetratelabs/proxy-wasm-go-sdk v0.20.1-0.20230115020858-593cf0f7417a h
 github.com/tetratelabs/proxy-wasm-go-sdk v0.20.1-0.20230115020858-593cf0f7417a/go.mod h1:62ObOye8ebDcihh92dIsVV+TgzjOehFeg8fruL6F12g=
 github.com/tetratelabs/wazero v1.0.0-pre.7 h1:WI5N14XxoXw+ZWhcjSazJ6rEowhJbH/x8hglxC5gN7k=
 github.com/tetratelabs/wazero v1.0.0-pre.7/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
-github.com/tidwall/gjson v1.14.3 h1:9jvXn7olKEHU1S9vwoMGliaT8jq1vJ7IH/n9zD9Dnlw=
-github.com/tidwall/gjson v1.14.3/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.14.4 h1:uo0p8EbA09J7RQaflQ1aBRffTR7xedD2bcIVSYxLnkM=
 github.com/tidwall/gjson v1.14.4/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=

--- a/main_test.go
+++ b/main_test.go
@@ -204,17 +204,17 @@ func TestLifecycle(t *testing.T) {
 			responded403:       true,
 			respondedNullBody:  false,
 		},
-		// {
-		// 	name: "request body accepted, no access",
-		// 	inlineRules: `
-		// SecRuleEngine On\nSecRequestBodyAccess Off\nSecRule REQUEST_BODY \"animal=bear\" \"id:101,phase:2,t:lowercase,deny\"
-		// `,
-		// 	requestHdrsAction:  types.ActionContinue,
-		// 	requestBodyAction:  types.ActionContinue,
-		// 	responseHdrsAction: types.ActionContinue,
-		// 	responded403:       false,
-		// 	respondedNullBody:  false,
-		// },
+		{
+			name: "request body accepted, no access",
+			inlineRules: `
+		SecRuleEngine On\nSecRequestBodyAccess Off\nSecRule REQUEST_BODY \"animal=bear\" \"id:101,phase:2,t:lowercase,deny\"
+		`,
+			requestHdrsAction:  types.ActionContinue,
+			requestBodyAction:  types.ActionContinue,
+			responseHdrsAction: types.ActionContinue,
+			responded403:       false,
+			respondedNullBody:  false,
+		},
 		{
 			name: "status accepted",
 			inlineRules: `

--- a/main_test.go
+++ b/main_test.go
@@ -214,7 +214,7 @@ func TestLifecycle(t *testing.T) {
 			respondedNullBody:  false,
 		},
 		{
-			name: "request body accepted, no access",
+			name: "request body accepted, no request body access",
 			inlineRules: `
 		SecRuleEngine On\nSecRequestBodyAccess Off\nSecRule REQUEST_BODY \"animal=bear\" \"id:101,phase:2,t:lowercase,deny\"
 		`,
@@ -401,10 +401,14 @@ func TestLifecycle(t *testing.T) {
 							body = reqBody[i : i+5]
 						}
 						requestBodyAction = host.CallOnRequestBody(id, body, eos)
-						if eos {
+						requestBodyAccess := strings.Contains(tt.inlineRules, "SecRequestBodyAccess On")
+						switch {
+						case eos:
 							requireEqualAction(t, tt.requestBodyAction, requestBodyAction, "unexpected body action, want %q, have %q on end of stream")
-						} else {
-							requireEqualAction(t, types.ActionPause, requestBodyAction, "unexpected body action, want %q, have %q")
+						case requestBodyAccess:
+							requireEqualAction(t, types.ActionPause, requestBodyAction, "unexpected request body action, want %q, have %q")
+						default:
+							requireEqualAction(t, types.ActionContinue, requestBodyAction, "unexpected request body action, want %q, have %q")
 						}
 					}
 				}
@@ -429,9 +433,9 @@ func TestLifecycle(t *testing.T) {
 						case eos:
 							requireEqualAction(t, types.ActionContinue, responseBodyAction, "unexpected response body action, want %q, have %q on end of stream")
 						case responseBodyAccess:
-							requireEqualAction(t, types.ActionPause, responseBodyAction, "unexpected response body action, want %q, have %q on end of stream")
+							requireEqualAction(t, types.ActionPause, responseBodyAction, "unexpected response body action, want %q, have %q")
 						default:
-							requireEqualAction(t, types.ActionContinue, responseBodyAction, "unexpected response body action, want %q, have %q on end of stream")
+							requireEqualAction(t, types.ActionContinue, responseBodyAction, "unexpected response body action, want %q, have %q")
 						}
 					}
 				}

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -58,11 +58,11 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 	conf := coraza.NewWAFConfig().
 		WithErrorCallback(logError).
 		WithDebugLogger(&debugLogger{}).
-		WithRequestBodyAccess(coraza.NewRequestBodyConfig().
-			WithLimit(1024 * 1024 * 1024).
-			// TinyGo compilation will prevent buffering request body to files anyways.
-			// TODO(anuraaga): Make this configurable in plugin configuration.
-			WithInMemoryLimit(1024 * 1024 * 1024)).
+		WithRequestBodyAccess().WithRequestBodyLimit(1024 * 1024 * 1024).
+		// Limit equal to MemoryLimit: TinyGo compilation will prevent
+		// buffering request body to files anyways.
+		// TODO(anuraaga): Make this configurable in plugin configuration.
+		WithRequestBodyInMemoryLimit(1024 * 1024 * 1024).
 		WithRootFS(root)
 
 	waf, err := coraza.NewWAF(conf.WithDirectives(strings.Join(config.rules, "\n")))

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -57,8 +57,7 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 	// First we initialize our waf and our seclang parser
 	conf := coraza.NewWAFConfig().
 		WithErrorCallback(logError).
-		WithDebugLogger(&debugLogger{}).
-		WithRequestBodyAccess().WithRequestBodyLimit(1024 * 1024 * 1024).
+		WithDebugLogger(&debugLogger{}).WithRequestBodyLimit(1024 * 1024 * 1024).
 		// Limit equal to MemoryLimit: TinyGo compilation will prevent
 		// buffering request body to files anyways.
 		// TODO(anuraaga): Make this configurable in plugin configuration.


### PR DESCRIPTION
Adrress broken changes introduced by [Flatters WAF config API for better flexibility in setting memory limits and enabling BodyAccess #503](https://github.com/corazawaf/coraza/pull/503).

The PR will be rebased after https://github.com/corazawaf/coraza-proxy-wasm/pull/131.