### PR TITLE
Use ubuntu base image for wasi-sdk

### DIFF
--- a/buildtools/wasi-sdk/Dockerfile
+++ b/buildtools/wasi-sdk/Dockerfile
@@ -1,13 +1,13 @@
 # Copyright 2022 The OWASP Coraza contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM debian:11-slim
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get install -y curl gnupg make
 
 RUN curl -sS https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/llvm.gpg && \
-    echo "deb [signed-by=/etc/apt/trusted.gpg.d/llvm.gpg] http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main" >> /etc/apt/sources.list.d/llvm.list && \
-    echo "deb-src [signed-by=/etc/apt/trusted.gpg.d/llvm.gpg] http://apt.llvm.org/bullseye/ llvm-toolchain-bullseye-15 main" >> /etc/apt/sources.list.d/llvm.list
+    echo "deb [signed-by=/etc/apt/trusted.gpg.d/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list.d/llvm.list && \
+    echo "deb-src [signed-by=/etc/apt/trusted.gpg.d/llvm.gpg] http://apt.llvm.org/jammy/ llvm-toolchain-jammy-15 main" >> /etc/apt/sources.list.d/llvm.list
 
 RUN apt-get update && apt-get install -y clang-15 lld-15
 


### PR DESCRIPTION
For newer binaryen package and to match upstream's (still not made public...) image