### PR TITLE
chore: updates debug log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ In order to run the coraza-proxy-wasm we need to spin up an envoy configuration 
                         value: |
                         {
                             "rules": [
-                                "SecDebugLogLevel 5",
+                                "SecDebugLogLevel 9",
                                 "SecRuleEngine On",
                                 "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""
                             ]
@@ -88,7 +88,7 @@ configuration:
     "@type": "type.googleapis.com/google.protobuf.StringValue"
     value: |
     {
-        "rules": [ "SecDebugLogLevel 5", "SecRuleEngine On", "Include @owasp_crs/*.conf" ]
+        "rules": [ "SecDebugLogLevel 9", "SecRuleEngine On", "Include @owasp_crs/*.conf" ]
     }
 ```
 
@@ -99,7 +99,7 @@ configuration:
     "@type": "type.googleapis.com/google.protobuf.StringValue"
     value: |
     {
-        "rules": [ "SecDebugLogLevel 5", "SecRuleEngine On", "Include @owasp_crs/REQUEST-901-INITIALIZATION.conf" ]
+        "rules": [ "SecDebugLogLevel 9", "SecRuleEngine On", "Include @owasp_crs/REQUEST-901-INITIALIZATION.conf" ]
     }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/corazawaf/coraza-proxy-wasm
 go 1.19
 
 require (
-	github.com/corazawaf/coraza/v3 v3.0.0-20230130131057-1baba981375c
+	github.com/corazawaf/coraza/v3 v3.0.0-20230203020113-719e7edfc0ac
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.21.0
 	github.com/tidwall/gjson v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/corazawaf/coraza/v3 v3.0.0-20230130131057-1baba981375c h1:MwHjmmoQL9K9R9AmkppCP2PNVTfnHH5wFQaJFYllAOw=
-github.com/corazawaf/coraza/v3 v3.0.0-20230130131057-1baba981375c/go.mod h1:dXFswKzaDVm4SsHAyvi12A4yLfg2bVx/myCBkyGALGU=
+github.com/corazawaf/coraza/v3 v3.0.0-20230203020113-719e7edfc0ac h1:7Z7S20RGR6kZNBjjhP0bPWdgVQuF1XqNIxxl9myBt/o=
+github.com/corazawaf/coraza/v3 v3.0.0-20230203020113-719e7edfc0ac/go.mod h1:dXFswKzaDVm4SsHAyvi12A4yLfg2bVx/myCBkyGALGU=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
 github.com/corazawaf/libinjection-go v0.1.2/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/wasmplugin/rules/coraza-demo.conf
+++ b/wasmplugin/rules/coraza-demo.conf
@@ -205,12 +205,12 @@ SecDataDir /tmp/
 
 # Default debug log path
 # Debug levels:
-# 1: fatal
-# 2: panic
-# 3: error
-# 4: warn
-# 5: info
-# 6: debug
+# 0: no logging (least verbose)
+# 1: error
+# 2: warn
+# 3: info
+# 4-5: debug
+# 6-9: trace (most verbose)
 # Most logging has not been implemented because it will be replaced with
 # advanced rule profiling options
 #SecDebugLog /opt/coraza/var/log/debug.log

--- a/wasmplugin/rules/coraza-demo.conf
+++ b/wasmplugin/rules/coraza-demo.conf
@@ -205,12 +205,12 @@ SecDataDir /tmp/
 
 # Default debug log path
 # Debug levels:
-# 0: no logging (least verbose)
-# 1: error
-# 2: warn
-# 3: info
-# 4-5: debug
-# 6-9: trace (most verbose)
+# 0:   No logging (least verbose)
+# 1:   Error
+# 2:   Warn
+# 3:   Info
+# 4-8: Debug
+# 9:   Trace (most verbose)
 # Most logging has not been implemented because it will be replaced with
 # advanced rule profiling options
 #SecDebugLog /opt/coraza/var/log/debug.log

--- a/wasmplugin/rules/coraza.conf-recommended.conf
+++ b/wasmplugin/rules/coraza.conf-recommended.conf
@@ -205,12 +205,12 @@ SecDataDir /tmp/
 
 # Default debug log path
 # Debug levels:
-# 1: fatal
-# 2: panic
-# 3: error
-# 4: warn
-# 5: info
-# 6: debug
+# 0: no logging (least verbose)
+# 1: error
+# 2: warn
+# 3: info
+# 4-5: debug
+# 6-9: trace (most verbose)
 # Most logging has not been implemented because it will be replaced with
 # advanced rule profiling options
 #SecDebugLog /opt/coraza/var/log/debug.log

--- a/wasmplugin/rules/coraza.conf-recommended.conf
+++ b/wasmplugin/rules/coraza.conf-recommended.conf
@@ -205,12 +205,12 @@ SecDataDir /tmp/
 
 # Default debug log path
 # Debug levels:
-# 0: no logging (least verbose)
-# 1: error
-# 2: warn
-# 3: info
-# 4-5: debug
-# 6-9: trace (most verbose)
+# 0:   No logging (least verbose)
+# 1:   Error
+# 2:   Warn
+# 3:   Info
+# 4-8: Debug
+# 9:   Trace (most verbose)
 # Most logging has not been implemented because it will be replaced with
 # advanced rule profiling options
 #SecDebugLog /opt/coraza/var/log/debug.log


### PR DESCRIPTION
Follows [Corrects SecDebugLogLevel doc, reorders logs levels #519](https://github.com/corazawaf/coraza/pull/519):
- updates some SecDebugLogLevel directives
- updates `.conf` files with the new levels