### PR TITLE
chore: avoids resolving target port if targetPortStr is empty.

### DIFF
--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -477,18 +477,18 @@ func logError(error ctypes.MatchedRule) {
 func retrieveAddressInfo(target string) (string, int) {
 	var targetIP, targetPortStr string
 	var targetPort int
-	srcAddressRaw, err := proxywasm.GetProperty([]string{target, "address"})
+	targetAddressRaw, err := proxywasm.GetProperty([]string{target, "address"})
 	if err != nil {
 		proxywasm.LogWarnf("failed to get %s address: %v", target, err)
 	} else {
-		targetIP, targetPortStr, err = net.SplitHostPort(string(srcAddressRaw))
+		targetIP, targetPortStr, err = net.SplitHostPort(string(targetAddressRaw))
 		if err != nil {
 			proxywasm.LogWarnf("failed to parse %s address: %v", target, err)
 		}
 	}
-	srcPortRaw, err := proxywasm.GetProperty([]string{target, "port"})
+	targetPortRaw, err := proxywasm.GetProperty([]string{target, "port"})
 	if err == nil {
-		targetPort, err = parsePort(srcPortRaw)
+		targetPort, err = parsePort(targetPortRaw)
 		if err != nil {
 			proxywasm.LogWarnf("failed to parse %s port: %v", target, err)
 		}

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -487,17 +487,17 @@ func retrieveAddressInfo(target string) (string, int) {
 		}
 	}
 	srcPortRaw, err := proxywasm.GetProperty([]string{target, "port"})
-	if err != nil {
+	if err == nil {
+		targetPort, err = parsePort(srcPortRaw)
+		if err != nil {
+			proxywasm.LogWarnf("failed to parse %s port: %v", target, err)
+		}
+	} else if targetPortStr != "" {
 		// If GetProperty fails we rely on the port inside the Address property
 		// Mostly useful for proxies other than Envoy
 		targetPort, err = strconv.Atoi(targetPortStr)
 		if err != nil {
 			proxywasm.LogInfof("failed to get %s port: %v", target, err)
-		}
-	} else {
-		targetPort, err = parsePort(srcPortRaw)
-		if err != nil {
-			proxywasm.LogWarnf("failed to parse %s port: %v", target, err)
 		}
 	}
 	return targetIP, targetPort

--- a/wasmplugin/plugin_test.go
+++ b/wasmplugin/plugin_test.go
@@ -5,7 +5,7 @@ package wasmplugin
 
 import (
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
@@ -14,25 +14,25 @@ import (
 
 func TestRetrieveAddressInfo(t *testing.T) {
 	testCases := map[string]struct {
-		address []byte
-		port []byte
+		address          []byte
+		port             []byte
 		expectedTargetIP string
-		expectedPort int
+		expectedPort     int
 	}{
 		"empty": {
 			expectedTargetIP: "",
-			expectedPort: 0,
+			expectedPort:     0,
 		},
 		"127.0.0.1:8080": {
-			address: []byte("127.0.0.10:8080"),
+			address:          []byte("127.0.0.10:8080"),
 			expectedTargetIP: "127.0.0.10",
-			expectedPort: 8080,
+			expectedPort:     8080,
 		},
 		"127.0.0.1:8080 with port": {
-			address: []byte("127.0.0.11:8080"),
-			port: []byte{5, 10, 0, 0, 0, 0, 0, 0}, // 256*10 + 5
+			address:          []byte("127.0.0.11:8080"),
+			port:             []byte{5, 10, 0, 0, 0, 0, 0, 0}, // 256*10 + 5
 			expectedTargetIP: "127.0.0.11",
-			expectedPort: 2565,
+			expectedPort:     2565,
 		},
 	}
 
@@ -43,20 +43,22 @@ func TestRetrieveAddressInfo(t *testing.T) {
 					opt := proxytest.
 						NewEmulatorOption().
 						WithVMContext(NewVMContext())
-				
+
 					host, reset := proxytest.NewHostEmulator(opt)
 					defer reset()
-				
+
 					require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
-				
+
 					id := host.InitializeHttpContext()
 
 					if len(tCase.address) > 0 {
-						host.SetProperty([]string{target, "address"}, []byte(tCase.address))
+						err := host.SetProperty([]string{target, "address"}, []byte(tCase.address))
+						require.NoError(t, err)
 					}
 
 					if len(tCase.port) > 0 {
-						host.SetProperty([]string{target, "port"}, []byte(tCase.port))
+						err := host.SetProperty([]string{target, "port"}, []byte(tCase.port))
+						require.NoError(t, err)
 					}
 
 					targetIP, port := retrieveAddressInfo(target)

--- a/wasmplugin/plugin_test.go
+++ b/wasmplugin/plugin_test.go
@@ -1,0 +1,71 @@
+// Copyright The OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package wasmplugin
+
+import (
+	"testing"
+	
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+func TestRetrieveAddressInfo(t *testing.T) {
+	testCases := map[string]struct {
+		address []byte
+		port []byte
+		expectedTargetIP string
+		expectedPort int
+	}{
+		"empty": {
+			expectedTargetIP: "",
+			expectedPort: 0,
+		},
+		"127.0.0.1:8080": {
+			address: []byte("127.0.0.10:8080"),
+			expectedTargetIP: "127.0.0.10",
+			expectedPort: 8080,
+		},
+		"127.0.0.1:8080 with port": {
+			address: []byte("127.0.0.11:8080"),
+			port: []byte{5, 10, 0, 0, 0, 0, 0, 0}, // 256*10 + 5
+			expectedTargetIP: "127.0.0.11",
+			expectedPort: 2565,
+		},
+	}
+
+	for _, target := range []string{"source", "destination"} {
+		t.Run(target, func(t *testing.T) {
+			for name, tCase := range testCases {
+				t.Run(name, func(t *testing.T) {
+					opt := proxytest.
+						NewEmulatorOption().
+						WithVMContext(NewVMContext())
+				
+					host, reset := proxytest.NewHostEmulator(opt)
+					defer reset()
+				
+					require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
+				
+					id := host.InitializeHttpContext()
+
+					if len(tCase.address) > 0 {
+						host.SetProperty([]string{target, "address"}, []byte(tCase.address))
+					}
+
+					if len(tCase.port) > 0 {
+						host.SetProperty([]string{target, "port"}, []byte(tCase.port))
+					}
+
+					targetIP, port := retrieveAddressInfo(target)
+					assert.Equal(t, tCase.expectedTargetIP, targetIP)
+					assert.Equal(t, tCase.expectedPort, port)
+
+					host.CompleteHttpContext(id)
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Currently we aim to resolve target port from the hostport, however if the target port as string is empty (most likely due to an error in the former operation) we should not attempt to turn that into an integer.