### PR TITLE
Feat: add busybox based image build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,6 +94,20 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}
 
+      - name: Docker meta busybox
+        id: meta-busybox
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}
+          flavor: |
+            suffix=-busybox
+
       - name: Login to GHCR
         uses: docker/login-action@v2
         with:
@@ -110,3 +124,15 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Build and push busybox based image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-busybox.outputs.tags }}
+          labels: ${{ steps.meta-busybox.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BASE_IMAGE=busybox:1.36-uclibc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Copyright 2022 The OWASP Coraza contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM scratch
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE:-scratch}
 
 COPY build/main.wasm /plugin.wasm


### PR DESCRIPTION
* Provides a ready-to-use `coraza-proxy-wasm` container image based on busybox that can be used as an `initContainer` of an envoy pod using [official images](https://hub.docker.com/r/envoyproxy/envoy) without having to build your own.

Basic example of a kubernetes manifest : 
```yaml
---
apiVersion: apps/v1
kind: Deployment
metadata:
  name: envoy-coraza
  labels:
    app: envoy-coraza
...
    spec:
      initContainers:
      - name: init-wasm
        image: ghcr.io/corazawaf/coraza-proxy-wasm:busybox
        command: ["/bin/sh"]
        args: ["-c", "cp /plugin.wasm /build/main.wasm"]
        volumeMounts:
          - name: wasm
            mountPath: "/build/"
      containers:
      - name:  envoy-coraza
        image:  envoyproxy/envoy:v1.23-latest
        volumeMounts:
        - name: envoy-coraza
          mountPath: /etc/envoy/
        - name: wasm
          mountPath: "/build/"
      volumes:
        - name: wasm
          emptyDir: {}
```