### PR TITLE
chore: Updates coraza and fixes related CRS configs

### DIFF
--- a/example/envoy-config.yaml
+++ b/example/envoy-config.yaml
@@ -44,6 +44,9 @@ static_resources:
                               "rules": [
                                 "Include @demo-conf",
                                 "Include @crs-setup-demo-conf",
+                                "SecDefaultAction \"phase:3,log,auditlog,pass\"",
+                                "SecDefaultAction \"phase:4,log,auditlog,pass\"",
+                                "SecDefaultAction \"phase:5,log,auditlog,pass\"",
                                 "SecDebugLogLevel 3",
                                 "Include @owasp_crs/*.conf",
                                 "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""

--- a/ftw/Dockerfile
+++ b/ftw/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2022 The OWASP Coraza contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/coreruleset/go-ftw:0.4.6
+FROM ghcr.io/coreruleset/go-ftw:0.4.7
 
 RUN apk update && apk add curl
 

--- a/ftw/ftw.yml
+++ b/ftw/ftw.yml
@@ -31,8 +31,6 @@ testoverride:
 
     # Failing tests to be addressed
     '920180-4': 'False positive. go-ftw sends POST / HTTP/2.0, but coraza-proxy-wasm reads HTTP/1.0. It does not happen with curl --http2-prior-knowledge'
-    '980170-1': 'Related to phase 4 logs. Not detected'
-    '980170-2': 'Related to phase 4 logs. Not detected'
 
     # Coraza related issues
     '920171-2': 'Rule 920171 not detected. GET/HEAD with body. Coraza side'

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089
-	github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975
+	github.com/corazawaf/coraza/v3 v3.0.0-20230308135426-06114602a8d5
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0
 	github.com/tidwall/gjson v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089 h1:g2hQT6RtJqt2pgs6W1Fc3EFq4pGBAAkyT0VPLwJsKvg=
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089/go.mod h1:J6mAYvwpBb16W9l2e/H6NFwK0OICzn3pWW56B4Lbz64=
-github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975 h1:UHOXatH3RvNgDJxnnUSpmx4MYmy9S3XksiSlYOcoMSA=
-github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
+github.com/corazawaf/coraza/v3 v3.0.0-20230308135426-06114602a8d5 h1:Rmq+B7LUbx4aVbKprQv3XSNX06YQh/yop9Xzj/bXZcE=
+github.com/corazawaf/coraza/v3 v3.0.0-20230308135426-06114602a8d5/go.mod h1:GhpyYpKaOG/wHZtdyUpu74wo9StS3fzmtKvgSzms/XQ=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
 github.com/corazawaf/libinjection-go v0.1.2/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -44,11 +44,11 @@ github.com/wasilibs/go-re2 v0.1.0 h1:+pcjlvge6E9WWU4eaMlULRikEUkhPDXSFfCF5p7htMI
 github.com/wasilibs/go-re2 v0.1.0/go.mod h1:F91Yac+zPNDFrrd8fl4mSd7+TTu2tYiX56BEIEPQl2M=
 github.com/wasilibs/nottinygc v0.2.0 h1:cXz2Ac9bVMLkpuOlUlPQMWowjw0K2cOErXZOFdAj7yE=
 github.com/wasilibs/nottinygc v0.2.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/wasmplugin/rules/ftw-config.conf
+++ b/wasmplugin/rules/ftw-config.conf
@@ -1,11 +1,13 @@
 # Overrides default SecResponseBodyMimeType in order to add application/json (httpbin response Content-Type)
 SecResponseBodyMimeType text/plain text/html text/xml application/json
 # crs-setup.conf.example defaults SecAction only for phase 1 and 2.
-# Adding logs for phase 3 and 4 otherwise go-ftw is not able to detected the triggered rules
+# Adding logs for phase 3, 4 and 5 otherwise go-ftw is not able to detected the triggered rules
 SecDefaultAction "phase:3,log,auditlog,pass"
 SecDefaultAction "phase:4,log,auditlog,pass"
+SecDefaultAction "phase:5,log,auditlog,pass"
 SecDebugLogLevel 3
 
+# Rule 900005 from https://github.com/coreruleset/coreruleset/blob/v4.0/dev/tests/regression/README.md#requirements
 # By default rule 900340 is commented, therefore max_file_size is added to 900005 in order to test 920400-* rules
 SecAction "id:900005,\
   phase:1,\
@@ -13,7 +15,7 @@ SecAction "id:900005,\
   pass,\
   ctl:ruleEngine=DetectionOnly,\
   ctl:ruleRemoveById=910000,\
-  setvar:tx.paranoia_level=4,\
+  setvar:tx.blocking_paranoia_level=4,\
   setvar:tx.crs_validate_utf8_encoding=1,\
   setvar:tx.arg_name_length=100,\
   setvar:tx.arg_length=400,\


### PR DESCRIPTION
In order to make https://github.com/corazawaf/coraza/pull/684 work, it is needed to:
- update `tx.paranoia_level outdated` CRS variable into `blocking_paranoia_level`
- add `SecDefaultAction “phase:5,log,auditlog,pass` otherwise correlation rules executed at phase 5 are not logged and ftw is not able to detect that these rules have been triggered.
Please refer to the upstream PRs for details: https://github.com/corazawaf/coraza/pull/684