### PR TITLE
chore: Updates coraza and fixes related CRS configs

### DIFF
--- a/example/envoy-config.yaml
+++ b/example/envoy-config.yaml
@@ -44,6 +44,9 @@ static_resources:
                               "rules": [
                                 "Include @demo-conf",
                                 "Include @crs-setup-demo-conf",
+                                "SecDefaultAction \"phase:3,log,auditlog,pass\"",
+                                "SecDefaultAction \"phase:4,log,auditlog,pass\"",
+                                "SecDefaultAction \"phase:5,log,auditlog,pass\"",
                                 "SecDebugLogLevel 3",
                                 "Include @owasp_crs/*.conf",
                                 "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""

--- a/ftw/Dockerfile
+++ b/ftw/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2022 The OWASP Coraza contributors
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ghcr.io/coreruleset/go-ftw:0.4.6
+FROM ghcr.io/coreruleset/go-ftw:0.4.7
 
 RUN apk update && apk add curl
 

--- a/ftw/ftw.yml
+++ b/ftw/ftw.yml
@@ -31,8 +31,6 @@ testoverride:
 
     # Failing tests to be addressed
     '920180-4': 'False positive. go-ftw sends POST / HTTP/2.0, but coraza-proxy-wasm reads HTTP/1.0. It does not happen with curl --http2-prior-knowledge'
-    '980170-1': 'Related to phase 4 logs. Not detected'
-    '980170-2': 'Related to phase 4 logs. Not detected'
 
     # Coraza related issues
     '920171-2': 'Rule 920171 not detected. GET/HEAD with body. Coraza side'

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089
-	github.com/corazawaf/coraza/v3 v3.0.0-20230306145445-20244e510e21
+	github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0
 	github.com/tidwall/gjson v1.14.4

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089
-	github.com/corazawaf/coraza/v3 v3.0.0-20230303111946-801a1d6be115
+	github.com/corazawaf/coraza/v3 v3.0.0-20230303204956-62a9224aeb65
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0
 	github.com/tidwall/gjson v1.14.4

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089
-	github.com/corazawaf/coraza/v3 v3.0.0-20230303204956-62a9224aeb65
+	github.com/corazawaf/coraza/v3 v3.0.0-20230306145445-20244e510e21
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0
 	github.com/tidwall/gjson v1.14.4
@@ -24,7 +24,7 @@ require (
 	github.com/wasilibs/go-aho-corasick v0.2.0 // indirect
 	github.com/wasilibs/go-libinjection v0.1.0 // indirect
 	github.com/wasilibs/go-re2 v0.1.0 // indirect
-	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/net v0.8.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089
-	github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975
+	github.com/corazawaf/coraza/v3 v3.0.0-20230308135426-06114602a8d5
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0
 	github.com/tidwall/gjson v1.14.4

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,7 @@
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089 h1:g2hQT6RtJqt2pgs6W1Fc3EFq4pGBAAkyT0VPLwJsKvg=
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089/go.mod h1:J6mAYvwpBb16W9l2e/H6NFwK0OICzn3pWW56B4Lbz64=
-github.com/corazawaf/coraza/v3 v3.0.0-20230306121642-f73733340113 h1:hPFt323nb3AC3VCxOyGsFYMH3wKdI0j3ESTUlVmFhVw=
-github.com/corazawaf/coraza/v3 v3.0.0-20230306121642-f73733340113/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
 github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975 h1:UHOXatH3RvNgDJxnnUSpmx4MYmy9S3XksiSlYOcoMSA=
 github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
-github.com/corazawaf/coraza/v3 v3.0.0-20230306145445-20244e510e21 h1:T5UHgw11VpL35iZYH/p79rbfI8ylY+1fYeDoEalxD2I=
-github.com/corazawaf/coraza/v3 v3.0.0-20230306145445-20244e510e21/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
 github.com/corazawaf/libinjection-go v0.1.2/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089 h1:g2hQT6RtJqt2pgs6W1Fc3EFq4pGBAAkyT0VPLwJsKvg=
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089/go.mod h1:J6mAYvwpBb16W9l2e/H6NFwK0OICzn3pWW56B4Lbz64=
-github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975 h1:UHOXatH3RvNgDJxnnUSpmx4MYmy9S3XksiSlYOcoMSA=
-github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
+github.com/corazawaf/coraza/v3 v3.0.0-20230308135426-06114602a8d5 h1:Rmq+B7LUbx4aVbKprQv3XSNX06YQh/yop9Xzj/bXZcE=
+github.com/corazawaf/coraza/v3 v3.0.0-20230308135426-06114602a8d5/go.mod h1:GhpyYpKaOG/wHZtdyUpu74wo9StS3fzmtKvgSzms/XQ=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
 github.com/corazawaf/libinjection-go v0.1.2/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -44,11 +44,11 @@ github.com/wasilibs/go-re2 v0.1.0 h1:+pcjlvge6E9WWU4eaMlULRikEUkhPDXSFfCF5p7htMI
 github.com/wasilibs/go-re2 v0.1.0/go.mod h1:F91Yac+zPNDFrrd8fl4mSd7+TTu2tYiX56BEIEPQl2M=
 github.com/wasilibs/nottinygc v0.2.0 h1:cXz2Ac9bVMLkpuOlUlPQMWowjw0K2cOErXZOFdAj7yE=
 github.com/wasilibs/nottinygc v0.2.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=
-golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
 golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
 golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
-golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
+golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089 h1:g2hQT6RtJqt2pgs6W1Fc3EFq4pGBAAkyT0VPLwJsKvg=
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089/go.mod h1:J6mAYvwpBb16W9l2e/H6NFwK0OICzn3pWW56B4Lbz64=
-github.com/corazawaf/coraza/v3 v3.0.0-20230303111946-801a1d6be115 h1:eNqWAzzPvdQcN5dPpS8raYKYJiDGs0QWccwqMniUvSk=
-github.com/corazawaf/coraza/v3 v3.0.0-20230303111946-801a1d6be115/go.mod h1:Eyif7jcOWEWJxyIj1JrStVR7vTjCBB5mbd+0FE9uYaQ=
+github.com/corazawaf/coraza/v3 v3.0.0-20230303204956-62a9224aeb65 h1:TCFmJ34R+8l8+b+hgANs2rX7jThVHZP/lCWuFi7iQwk=
+github.com/corazawaf/coraza/v3 v3.0.0-20230303204956-62a9224aeb65/go.mod h1:Eyif7jcOWEWJxyIj1JrStVR7vTjCBB5mbd+0FE9uYaQ=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
 github.com/corazawaf/libinjection-go v0.1.2/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089 h1:g2hQT6RtJqt2pgs6W1Fc3EFq4pGBAAkyT0VPLwJsKvg=
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089/go.mod h1:J6mAYvwpBb16W9l2e/H6NFwK0OICzn3pWW56B4Lbz64=
+github.com/corazawaf/coraza/v3 v3.0.0-20230306121642-f73733340113 h1:hPFt323nb3AC3VCxOyGsFYMH3wKdI0j3ESTUlVmFhVw=
+github.com/corazawaf/coraza/v3 v3.0.0-20230306121642-f73733340113/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
+github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975 h1:UHOXatH3RvNgDJxnnUSpmx4MYmy9S3XksiSlYOcoMSA=
+github.com/corazawaf/coraza/v3 v3.0.0-20230306125904-229f7fff9975/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
 github.com/corazawaf/coraza/v3 v3.0.0-20230306145445-20244e510e21 h1:T5UHgw11VpL35iZYH/p79rbfI8ylY+1fYeDoEalxD2I=
 github.com/corazawaf/coraza/v3 v3.0.0-20230306145445-20244e510e21/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089 h1:g2hQT6RtJqt2pgs6W1Fc3EFq4pGBAAkyT0VPLwJsKvg=
 github.com/corazawaf/coraza-wasilibs v0.0.0-20230203072127-1efe825d0089/go.mod h1:J6mAYvwpBb16W9l2e/H6NFwK0OICzn3pWW56B4Lbz64=
-github.com/corazawaf/coraza/v3 v3.0.0-20230303204956-62a9224aeb65 h1:TCFmJ34R+8l8+b+hgANs2rX7jThVHZP/lCWuFi7iQwk=
-github.com/corazawaf/coraza/v3 v3.0.0-20230303204956-62a9224aeb65/go.mod h1:Eyif7jcOWEWJxyIj1JrStVR7vTjCBB5mbd+0FE9uYaQ=
+github.com/corazawaf/coraza/v3 v3.0.0-20230306145445-20244e510e21 h1:T5UHgw11VpL35iZYH/p79rbfI8ylY+1fYeDoEalxD2I=
+github.com/corazawaf/coraza/v3 v3.0.0-20230306145445-20244e510e21/go.mod h1:bLyQJ+i9Nc5y7OH7ZznU8SX4Vmr25Ak1MpPbeVoIhRo=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
 github.com/corazawaf/libinjection-go v0.1.2/go.mod h1:OP4TM7xdJ2skyXqNX1AN1wN5nNZEmJNuWbNPOItn7aw=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -45,9 +45,9 @@ github.com/wasilibs/go-re2 v0.1.0/go.mod h1:F91Yac+zPNDFrrd8fl4mSd7+TTu2tYiX56BE
 github.com/wasilibs/nottinygc v0.2.0 h1:cXz2Ac9bVMLkpuOlUlPQMWowjw0K2cOErXZOFdAj7yE=
 github.com/wasilibs/nottinygc v0.2.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 h1:6zppjxzCulZykYSLyVDYbneBfbaBIQPYMevg0bEwv2s=
-golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
-golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
+golang.org/x/net v0.8.0 h1:Zrh2ngAOFYneWTAIAPethzeaQLuHwhuBkuV6ZiRnUaQ=
+golang.org/x/net v0.8.0/go.mod h1:QVkue5JL9kW//ek3r6jTKnTFis1tRmNAW2P1shuFdJc=
+golang.org/x/sys v0.6.0 h1:MVltZSvRTcU2ljQOhs94SXPftV6DCNnZViHeQps87pQ=
 golang.org/x/tools v0.1.12 h1:VveCTK38A2rkS8ZqFY25HIDFscX5X9OoEhJd3quQmXU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/main_test.go
+++ b/main_test.go
@@ -534,7 +534,7 @@ func TestBadConfig(t *testing.T) {
 		{
 			name: "bad json",
 			conf: "{",
-			msg:  `error parsing plugin configuration:`,
+			msg:  `Failed to parse plugin configuration:`,
 		},
 	}
 
@@ -570,14 +570,14 @@ func TestBadRequest(t *testing.T) {
 			reqHdrs: [][2]string{
 				{":method", "GET"},
 			},
-			msg: "failed to get :path",
+			msg: "Failed to get :path",
 		},
 		{
 			name: "missing method",
 			reqHdrs: [][2]string{
 				{":path", "/hello"},
 			},
-			msg: "failed to get :method",
+			msg: "Failed to get :method",
 		},
 	}
 
@@ -599,7 +599,7 @@ func TestBadRequest(t *testing.T) {
 				action := host.CallOnRequestHeaders(id, tt.reqHdrs, false)
 				require.Equal(t, types.ActionContinue, action)
 
-				logs := strings.Join(host.GetCriticalLogs(), "\n")
+				logs := strings.Join(host.GetErrorLogs(), "\n")
 				require.Contains(t, logs, tt.msg)
 			})
 		}
@@ -617,7 +617,7 @@ func TestBadResponse(t *testing.T) {
 			respHdrs: [][2]string{
 				{"content-length", "12"},
 			},
-			msg: "failed to get :status",
+			msg: "Failed to get :status",
 		},
 	}
 
@@ -639,7 +639,7 @@ func TestBadResponse(t *testing.T) {
 				action := host.CallOnResponseHeaders(id, tt.respHdrs, false)
 				require.Equal(t, types.ActionContinue, action)
 
-				logs := strings.Join(host.GetCriticalLogs(), "\n")
+				logs := strings.Join(host.GetErrorLogs(), "\n")
 				require.Contains(t, logs, tt.msg)
 			})
 		}

--- a/wasmplugin/logger.go
+++ b/wasmplugin/logger.go
@@ -6,50 +6,45 @@ package wasmplugin
 import (
 	"io"
 
-	"github.com/corazawaf/coraza/v3/loggers"
+	"github.com/corazawaf/coraza/v3/debuglogger"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 )
 
-type debugLogger struct {
-	level loggers.LogLevel
+type logger struct {
+	debuglogger.Logger
 }
 
-var _ loggers.DebugLogger = (*debugLogger)(nil)
+var _ debuglogger.Logger = logger{}
 
-func (l *debugLogger) Info(message string, args ...interface{}) {
-	if l.level >= loggers.LogLevelInfo {
-		proxywasm.LogInfof(message, args...)
+var logPrinterFactory = func(io.Writer) debuglogger.Printer {
+	return func(lvl debuglogger.LogLevel, message, fields string) {
+		switch lvl {
+		case debuglogger.LogLevelTrace:
+			proxywasm.LogTracef("%s %s", message, fields)
+		case debuglogger.LogLevelDebug:
+			proxywasm.LogDebugf("%s %s", message, fields)
+		case debuglogger.LogLevelInfo:
+			proxywasm.LogInfof("%s %s", message, fields)
+		case debuglogger.LogLevelWarn:
+			proxywasm.LogWarnf("%s %s", message, fields)
+		case debuglogger.LogLevelError:
+			proxywasm.LogErrorf("%s %s", message, fields)
+		default:
+		}
 	}
 }
 
-func (l *debugLogger) Warn(message string, args ...interface{}) {
-	if l.level >= loggers.LogLevelWarn {
-		proxywasm.LogWarnf(message, args...)
+func DefaultLogger() debuglogger.Logger {
+	return logger{
+		debuglogger.DefaultWithPrinterFactory(logPrinterFactory),
 	}
 }
 
-func (l *debugLogger) Error(message string, args ...interface{}) {
-	if l.level >= loggers.LogLevelError {
-		proxywasm.LogErrorf(message, args...)
-	}
+func (l logger) WithLevel(lvl debuglogger.LogLevel) debuglogger.Logger {
+	return logger{l.Logger.WithLevel(lvl)}
 }
 
-func (l *debugLogger) Debug(message string, args ...interface{}) {
-	if l.level >= loggers.LogLevelDebug {
-		proxywasm.LogDebugf(message, args...)
-	}
-}
-
-func (l *debugLogger) Trace(message string, args ...interface{}) {
-	if l.level >= loggers.LogLevelTrace {
-		proxywasm.LogTracef(message, args...)
-	}
-}
-
-func (l *debugLogger) SetLevel(level loggers.LogLevel) {
-	l.level = level
-}
-
-func (l *debugLogger) SetOutput(w io.WriteCloser) {
+func (l logger) WithOutput(_ io.Writer) debuglogger.Logger {
 	proxywasm.LogWarn("ignoring SecDebugLog directive, debug logs are always routed to proxy logs")
+	return l
 }

--- a/wasmplugin/logger.go
+++ b/wasmplugin/logger.go
@@ -6,45 +6,45 @@ package wasmplugin
 import (
 	"io"
 
-	"github.com/corazawaf/coraza/v3/debuglogger"
+	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 )
 
 type logger struct {
-	debuglogger.Logger
+	debuglog.Logger
 }
 
-var _ debuglogger.Logger = logger{}
+var _ debuglog.Logger = logger{}
 
-var logPrinterFactory = func(io.Writer) debuglogger.Printer {
-	return func(lvl debuglogger.LogLevel, message, fields string) {
+var logPrinterFactory = func(io.Writer) debuglog.Printer {
+	return func(lvl debuglog.LogLevel, message, fields string) {
 		switch lvl {
-		case debuglogger.LogLevelTrace:
+		case debuglog.LogLevelTrace:
 			proxywasm.LogTracef("%s %s", message, fields)
-		case debuglogger.LogLevelDebug:
+		case debuglog.LogLevelDebug:
 			proxywasm.LogDebugf("%s %s", message, fields)
-		case debuglogger.LogLevelInfo:
+		case debuglog.LogLevelInfo:
 			proxywasm.LogInfof("%s %s", message, fields)
-		case debuglogger.LogLevelWarn:
+		case debuglog.LogLevelWarn:
 			proxywasm.LogWarnf("%s %s", message, fields)
-		case debuglogger.LogLevelError:
+		case debuglog.LogLevelError:
 			proxywasm.LogErrorf("%s %s", message, fields)
 		default:
 		}
 	}
 }
 
-func DefaultLogger() debuglogger.Logger {
+func DefaultLogger() debuglog.Logger {
 	return logger{
-		debuglogger.DefaultWithPrinterFactory(logPrinterFactory),
+		debuglog.DefaultWithPrinterFactory(logPrinterFactory),
 	}
 }
 
-func (l logger) WithLevel(lvl debuglogger.LogLevel) debuglogger.Logger {
+func (l logger) WithLevel(lvl debuglog.LogLevel) debuglog.Logger {
 	return logger{l.Logger.WithLevel(lvl)}
 }
 
-func (l logger) WithOutput(_ io.Writer) debuglogger.Logger {
+func (l logger) WithOutput(_ io.Writer) debuglog.Logger {
 	proxywasm.LogWarn("ignoring SecDebugLog directive, debug logs are always routed to proxy logs")
 	return l
 }

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -7,12 +7,14 @@ import (
 	"bytes"
 	"encoding/binary"
 	"errors"
+	"fmt"
 	"math"
 	"net"
 	"strconv"
 	"strings"
 
 	"github.com/corazawaf/coraza/v3"
+	"github.com/corazawaf/coraza/v3/debuglogger"
 	ctypes "github.com/corazawaf/coraza/v3/types"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
@@ -50,14 +52,14 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 	}
 	config, err := parsePluginConfiguration(data)
 	if err != nil {
-		proxywasm.LogCriticalf("error parsing plugin configuration: %v", err)
+		proxywasm.LogCriticalf("Failed to parse plugin configuration: %v", err)
 		return types.OnPluginStartStatusFailed
 	}
 
 	// First we initialize our waf and our seclang parser
 	conf := coraza.NewWAFConfig().
 		WithErrorCallback(logError).
-		WithDebugLogger(&debugLogger{}).
+		WithDebugLogger(debuglogger.DefaultWithPrinterFactory(logPrinterFactory)).
 		// TODO(anuraaga): Make this configurable in plugin configuration.
 		// WithRequestBodyLimit(1024 * 1024 * 1024).
 		// WithRequestBodyInMemoryLimit(1024 * 1024 * 1024).
@@ -67,7 +69,7 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 
 	waf, err := coraza.NewWAF(conf.WithDirectives(strings.Join(config.rules, "\n")))
 	if err != nil {
-		proxywasm.LogCriticalf("failed to parse rules: %v", err)
+		proxywasm.LogCriticalf("Failed to parse rules: %v", err)
 		return types.OnPluginStartStatusFailed
 	}
 
@@ -84,6 +86,9 @@ func (ctx *corazaPlugin) NewHttpContext(contextID uint32) types.HttpContext {
 		tx:        ctx.waf.NewTransaction(),
 		// TODO(jcchavezs): figure out how/when enable/disable metrics
 		metrics: ctx.metrics,
+		logger: ctx.waf.NewTransaction().
+			DebugLogger().
+			With(debuglogger.Uint("context_id", uint(contextID))),
 	}
 }
 
@@ -99,6 +104,7 @@ type httpContext struct {
 	bodyReadIndex         int
 	metrics               *wafMetrics
 	interruptionHandled   bool
+	logger                debuglogger.Logger
 }
 
 func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
@@ -115,8 +121,8 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 		return types.ActionContinue
 	}
 	// OnHttpRequestHeaders does not terminate if IP/Port retrieve goes wrong
-	srcIP, srcPort := retrieveAddressInfo("source")
-	dstIP, dstPort := retrieveAddressInfo("destination")
+	srcIP, srcPort := retrieveAddressInfo(ctx.logger, "source")
+	dstIP, dstPort := retrieveAddressInfo(ctx.logger, "destination")
 
 	tx.ProcessConnection(srcIP, srcPort, dstIP, dstPort)
 
@@ -124,13 +130,17 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 	// See https://httpwg.org/specs/rfc9113.html#rfc.section.8.3.1
 	uri, err := proxywasm.GetHttpRequestHeader(":path")
 	if err != nil {
-		proxywasm.LogCriticalf("failed to get :path: %v", err)
+		ctx.logger.Error().
+			Err(err).
+			Msg("Failed to get :path")
 		return types.ActionContinue
 	}
 
 	method, err := proxywasm.GetHttpRequestHeader(":method")
 	if err != nil {
-		proxywasm.LogCriticalf("failed to get :method: %v", err)
+		ctx.logger.Error().
+			Err(err).
+			Msg("Failed to get :method")
 		return types.ActionContinue
 	}
 
@@ -147,7 +157,7 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 
 	hs, err := proxywasm.GetHttpRequestHeaders()
 	if err != nil {
-		proxywasm.LogCriticalf("failed to get request headers: %v", err)
+		ctx.logger.Error().Err(err).Msg("Failed to get request headers")
 		return types.ActionContinue
 	}
 
@@ -159,7 +169,7 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 	authority, err := proxywasm.GetHttpRequestHeader(":authority")
 	if err == nil {
 		tx.AddRequestHeader("Host", authority)
-		tx.SetServerName(parseServerName(authority))
+		tx.SetServerName(parseServerName(ctx.logger, authority))
 	}
 
 	interruption := tx.ProcessRequestHeaders()
@@ -174,7 +184,7 @@ func (ctx *httpContext) OnHttpRequestBody(bodySize int, endOfStream bool) types.
 	defer logTime("OnHttpRequestBody", currentTime())
 
 	if ctx.interruptionHandled {
-		proxywasm.LogErrorf("interruption already handled")
+		ctx.logger.Error().Msg("Interruption already handled")
 		return types.ActionPause
 	}
 
@@ -190,12 +200,12 @@ func (ctx *httpContext) OnHttpRequestBody(bodySize int, endOfStream bool) types.
 
 	// Do not perform any action related to request body data if SecRequestBodyAccess is set to false
 	if !tx.IsRequestBodyAccessible() {
-		proxywasm.LogDebug("skipping request body inspection, SecRequestBodyAccess is off.")
+		ctx.logger.Debug().Msg("Skipping request body inspection, SecRequestBodyAccess is off.")
 		// ProcessRequestBody is still performed for phase 2 rules, checking already populated variables
 		ctx.processedRequestBody = true
 		interruption, err := tx.ProcessRequestBody()
 		if err != nil {
-			proxywasm.LogCriticalf("failed to process request body: %v", err)
+			ctx.logger.Error().Err(err).Msg("Failed to process request body")
 			return types.ActionContinue
 		}
 
@@ -211,7 +221,7 @@ func (ctx *httpContext) OnHttpRequestBody(bodySize int, endOfStream bool) types.
 		if err == nil {
 			interruption, _, err := tx.WriteRequestBody(b)
 			if err != nil {
-				proxywasm.LogCriticalf("failed to write request body: %v", err)
+				ctx.logger.Error().Err(err).Msg("Failed to write request body")
 				return types.ActionContinue
 			}
 
@@ -229,7 +239,11 @@ func (ctx *httpContext) OnHttpRequestBody(bodySize int, endOfStream bool) types.
 			// endOfStream being true or false.
 			// The tests in 920410 show this problem.
 			// TODO(jcchavezs): Verify if this is a FTW problem.
-			proxywasm.LogCriticalf("failed to read request body from %d up to %d bytes: %v", ctx.bodyReadIndex, bodySize, err)
+			ctx.logger.Error().
+				Err(err).
+				Int("body_read_index", ctx.bodyReadIndex).
+				Int("body_size", bodySize).
+				Msg("Failed to read request body")
 			return types.ActionContinue
 		}
 	}
@@ -239,7 +253,9 @@ func (ctx *httpContext) OnHttpRequestBody(bodySize int, endOfStream bool) types.
 		ctx.bodyReadIndex = 0 // cleaning for further usage
 		interruption, err := tx.ProcessRequestBody()
 		if err != nil {
-			proxywasm.LogCriticalf("failed to process request body: %v", err)
+			ctx.logger.Error().
+				Err(err).
+				Msg("Failed to process request body")
 			return types.ActionContinue
 		}
 		if interruption != nil {
@@ -262,10 +278,10 @@ func (ctx *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) 
 		// We expect a response that is ending the stream, with exactly one header (:status) and no body.
 		// See https://github.com/corazawaf/coraza-proxy-wasm/pull/126
 		if numHeaders == 1 && endOfStream {
-			proxywasm.LogDebugf("interruption already handled, sending downstream the local response")
+			ctx.logger.Debug().Msg("Interruption already handled, sending downstream the local response")
 			return types.ActionContinue
 		} else {
-			proxywasm.LogErrorf("interruption already handled, unexpected local response")
+			ctx.logger.Error().Msg("Interruption already handled, unexpected local response")
 			return types.ActionPause
 		}
 	}
@@ -282,7 +298,8 @@ func (ctx *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) 
 		ctx.processedRequestBody = true
 		interruption, err := tx.ProcessRequestBody()
 		if err != nil {
-			proxywasm.LogCriticalf("failed to process request body: %v", err)
+			ctx.logger.Error().
+				Err(err).Msg("Failed to process request body")
 			return types.ActionContinue
 		}
 		if interruption != nil {
@@ -292,7 +309,9 @@ func (ctx *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) 
 
 	status, err := proxywasm.GetHttpResponseHeader(":status")
 	if err != nil {
-		proxywasm.LogCriticalf("failed to get :status: %v", err)
+		ctx.logger.Error().
+			Err(err).
+			Msg("Failed to get :status")
 		return types.ActionContinue
 	}
 	code, err := strconv.Atoi(status)
@@ -302,7 +321,9 @@ func (ctx *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) 
 
 	hs, err := proxywasm.GetHttpResponseHeaders()
 	if err != nil {
-		proxywasm.LogCriticalf("failed to get response headers: %v", err)
+		ctx.logger.Error().
+			Err(err).
+			Msg("Failed to get response headers")
 		return types.ActionContinue
 	}
 
@@ -327,9 +348,10 @@ func (ctx *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types
 		// If OnHttpResponseBody is called again and an interruption has already been raised, it means that
 		// we have to keep going with the sanitization of the response, emptying it.
 		// Sending the crafted HttpResponse with empty body, we don't expect to trigger OnHttpResponseBody
-		proxywasm.LogWarn("response body interruption already handled, keeping replacing the body")
+		ctx.logger.Warn().
+			Msg("Response body interruption already handled, keeping replacing the body")
 		// Interruption happened, we don't want to send response body data
-		return replaceResponseBodyWhenInterrupted(bodySize)
+		return replaceResponseBodyWhenInterrupted(ctx.logger, bodySize)
 	}
 
 	tx := ctx.tx
@@ -340,12 +362,12 @@ func (ctx *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types
 
 	// Do not perform any action related to response body data if SecResponseBodyAccess is set to false
 	if !tx.IsResponseBodyAccessible() {
-		proxywasm.LogDebug("skipping response body inspection, SecResponseBodyAccess is off.")
+		ctx.logger.Debug().Msg("Skipping response body inspection, SecResponseBodyAccess is off.")
 		// ProcessResponseBody is performed for phase 4 rules, checking already populated variables
 		ctx.processedResponseBody = true
 		interruption, err := tx.ProcessResponseBody()
 		if err != nil {
-			proxywasm.LogCriticalf("failed to process response body: %v", err)
+			ctx.logger.Error().Err(err).Msg("Failed to process response body")
 			return types.ActionContinue
 		}
 
@@ -363,7 +385,7 @@ func (ctx *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types
 		if err == nil {
 			interruption, _, err := tx.WriteResponseBody(body)
 			if err != nil {
-				proxywasm.LogCriticalf("failed to write response body: %v", err)
+				ctx.logger.Error().Err(err).Msg("Failed to write response body")
 				return types.ActionContinue
 			}
 			// bodyReadIndex has to be updated before evaluating the interruption
@@ -373,7 +395,11 @@ func (ctx *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types
 				return ctx.handleInterruption("http_response_body", interruption)
 			}
 		} else if err != types.ErrorStatusNotFound {
-			proxywasm.LogCriticalf("failed to read response body from %d up to %d bytes: %v", ctx.bodyReadIndex, bodySize, err)
+			ctx.logger.Error().
+				Int("body_read_index", ctx.bodyReadIndex).
+				Int("body_size", bodySize).
+				Err(err).
+				Msg("Failed to read response body")
 			return types.ActionContinue
 		}
 	}
@@ -385,7 +411,9 @@ func (ctx *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types
 		ctx.processedResponseBody = true
 		interruption, err := tx.ProcessResponseBody()
 		if err != nil {
-			proxywasm.LogCriticalf("failed to process response body: %v", err)
+			ctx.logger.Error().
+				Err(err).
+				Msg("Failed to process response body")
 			return types.ActionContinue
 		}
 		if interruption != nil {
@@ -409,7 +437,9 @@ func (ctx *httpContext) OnHttpStreamDone() {
 			ctx.processedResponseBody = true
 			_, err := tx.ProcessResponseBody()
 			if err != nil {
-				proxywasm.LogCriticalf("failed to process response body: %v", err)
+				ctx.logger.Error().
+					Err(err).
+					Msg("Failed to process response body")
 			}
 		}
 	}
@@ -418,7 +448,7 @@ func (ctx *httpContext) OnHttpStreamDone() {
 	ctx.tx.ProcessLogging()
 
 	_ = ctx.tx.Close()
-	proxywasm.LogInfof("%d finished", ctx.contextID)
+	ctx.logger.Info().Msg("Finished")
 	logMemStats()
 }
 
@@ -427,15 +457,19 @@ const noGRPCStream int32 = -1
 func (ctx *httpContext) handleInterruption(phase string, interruption *ctypes.Interruption) types.Action {
 	if ctx.interruptionHandled {
 		// handleInterruption should never be called more than once
-		panic("interruption already handled")
+		panic("Interruption already handled")
 	}
 
 	ctx.metrics.CountTXInterruption(phase, interruption.RuleID)
 
-	proxywasm.LogInfof("%d interrupted, action %q, phase %q", ctx.contextID, interruption.Action, phase)
+	ctx.logger.Info().
+		Str("action", interruption.Action).
+		Str("phase", phase).
+		Msg("Transaction interrupted")
+
 	ctx.interruptionHandled = true
 	if phase == "http_response_body" {
-		return replaceResponseBodyWhenInterrupted(ctx.bodyReadIndex)
+		return replaceResponseBodyWhenInterrupted(ctx.logger, ctx.bodyReadIndex)
 	}
 
 	statusCode := interruption.Status
@@ -475,30 +509,39 @@ func logError(error ctypes.MatchedRule) {
 // retrieveAddressInfo retrieves address properties from the proxy
 // Expected targets are "source" or "destination"
 // Envoy ref: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#connection-attributes
-func retrieveAddressInfo(target string) (string, int) {
+func retrieveAddressInfo(logger debuglogger.Logger, target string) (string, int) {
 	var targetIP, targetPortStr string
 	var targetPort int
 	targetAddressRaw, err := proxywasm.GetProperty([]string{target, "address"})
 	if err != nil {
-		proxywasm.LogWarnf("failed to get %s address: %v", target, err)
+		logger.Warn().
+			Err(err).
+			Msg(fmt.Sprintf("Failed to get %s address", target))
 	} else {
 		targetIP, targetPortStr, err = net.SplitHostPort(string(targetAddressRaw))
 		if err != nil {
-			proxywasm.LogWarnf("failed to parse %s address: %v", target, err)
+			logger.Warn().
+				Err(err).
+				Msg(fmt.Sprintf("Failed to parse %s address", target))
 		}
 	}
 	targetPortRaw, err := proxywasm.GetProperty([]string{target, "port"})
 	if err == nil {
 		targetPort, err = parsePort(targetPortRaw)
 		if err != nil {
-			proxywasm.LogWarnf("failed to parse %s port: %v", target, err)
+			logger.Warn().
+				Err(err).
+				Msg(fmt.Sprintf("Failed to parse %s port", target))
 		}
 	} else if targetPortStr != "" {
 		// If GetProperty fails we rely on the port inside the Address property
 		// Mostly useful for proxies other than Envoy
 		targetPort, err = strconv.Atoi(targetPortStr)
 		if err != nil {
-			proxywasm.LogInfof("failed to get %s port: %v", target, err)
+			logger.Warn().
+				Err(err).
+				Msg(fmt.Sprintf("Failed to get %s port", target))
+
 		}
 	}
 	return targetIP, targetPort
@@ -523,25 +566,28 @@ func parsePort(b []byte) (int, error) {
 // replaceResponseBodyWhenInterrupted address an interruption raised during phase 4.
 // At this phase, response headers are already sent downstream, therefore an interruption
 // can not change anymore the status code, but only tweak the response body
-func replaceResponseBodyWhenInterrupted(bodySize int) types.Action {
+func replaceResponseBodyWhenInterrupted(logger debuglogger.Logger, bodySize int) types.Action {
 	// TODO(M4tteoP): Update response body interruption logic after https://github.com/corazawaf/coraza-proxy-wasm/issues/26
 	// Currently returns a body filled with null bytes that replaces the sensitive data potentially leaked
 	err := proxywasm.ReplaceHttpResponseBody(bytes.Repeat([]byte("\x00"), bodySize))
 	if err != nil {
-		proxywasm.LogErrorf("failed to replace response body: %v", err)
+		logger.Error().Err(err).Msg("Failed to replace response body")
 		return types.ActionContinue
 	}
-	proxywasm.LogWarn("response body intervention occurred: body replaced")
+	logger.Warn().Msg("Response body intervention occurred: body replaced")
 	return types.ActionContinue
 }
 
 // parseServerName parses :authority pseudo-header in order to retrieve the
 // virtual host.
-func parseServerName(authority string) string {
+func parseServerName(logger debuglogger.Logger, authority string) string {
 	host, _, err := net.SplitHostPort(authority)
 	if err != nil {
 		// missing port or bad format
-		proxywasm.LogDebugf("failed to parse server name from authority %q, %v", authority, err)
+		logger.Debug().
+			Str("authority", authority).
+			Err(err).
+			Msg("Failed to parse server name from authority")
 		host = authority
 	}
 	return host

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/corazawaf/coraza/v3"
-	"github.com/corazawaf/coraza/v3/debuglogger"
+	"github.com/corazawaf/coraza/v3/debuglog"
 	ctypes "github.com/corazawaf/coraza/v3/types"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
@@ -59,7 +59,7 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 	// First we initialize our waf and our seclang parser
 	conf := coraza.NewWAFConfig().
 		WithErrorCallback(logError).
-		WithDebugLogger(debuglogger.DefaultWithPrinterFactory(logPrinterFactory)).
+		WithDebugLogger(debuglog.DefaultWithPrinterFactory(logPrinterFactory)).
 		// TODO(anuraaga): Make this configurable in plugin configuration.
 		// WithRequestBodyLimit(1024 * 1024 * 1024).
 		// WithRequestBodyInMemoryLimit(1024 * 1024 * 1024).
@@ -88,7 +88,7 @@ func (ctx *corazaPlugin) NewHttpContext(contextID uint32) types.HttpContext {
 		metrics: ctx.metrics,
 		logger: ctx.waf.NewTransaction().
 			DebugLogger().
-			With(debuglogger.Uint("context_id", uint(contextID))),
+			With(debuglog.Uint("context_id", uint(contextID))),
 	}
 }
 
@@ -104,7 +104,7 @@ type httpContext struct {
 	bodyReadIndex         int
 	metrics               *wafMetrics
 	interruptionHandled   bool
-	logger                debuglogger.Logger
+	logger                debuglog.Logger
 }
 
 func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
@@ -509,7 +509,7 @@ func logError(error ctypes.MatchedRule) {
 // retrieveAddressInfo retrieves address properties from the proxy
 // Expected targets are "source" or "destination"
 // Envoy ref: https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/attributes#connection-attributes
-func retrieveAddressInfo(logger debuglogger.Logger, target string) (string, int) {
+func retrieveAddressInfo(logger debuglog.Logger, target string) (string, int) {
 	var targetIP, targetPortStr string
 	var targetPort int
 	targetAddressRaw, err := proxywasm.GetProperty([]string{target, "address"})
@@ -566,7 +566,7 @@ func parsePort(b []byte) (int, error) {
 // replaceResponseBodyWhenInterrupted address an interruption raised during phase 4.
 // At this phase, response headers are already sent downstream, therefore an interruption
 // can not change anymore the status code, but only tweak the response body
-func replaceResponseBodyWhenInterrupted(logger debuglogger.Logger, bodySize int) types.Action {
+func replaceResponseBodyWhenInterrupted(logger debuglog.Logger, bodySize int) types.Action {
 	// TODO(M4tteoP): Update response body interruption logic after https://github.com/corazawaf/coraza-proxy-wasm/issues/26
 	// Currently returns a body filled with null bytes that replaces the sensitive data potentially leaked
 	err := proxywasm.ReplaceHttpResponseBody(bytes.Repeat([]byte("\x00"), bodySize))
@@ -580,7 +580,7 @@ func replaceResponseBodyWhenInterrupted(logger debuglogger.Logger, bodySize int)
 
 // parseServerName parses :authority pseudo-header in order to retrieve the
 // virtual host.
-func parseServerName(logger debuglogger.Logger, authority string) string {
+func parseServerName(logger debuglog.Logger, authority string) string {
 	host, _, err := net.SplitHostPort(authority)
 	if err != nil {
 		// missing port or bad format

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -87,8 +87,8 @@ func (ctx *corazaPlugin) NewHttpContext(contextID uint32) types.HttpContext {
 		// TODO(jcchavezs): figure out how/when enable/disable metrics
 		metrics: ctx.metrics,
 		logger: ctx.waf.NewTransaction().
-			DebugLogger().
-			With(debuglog.Uint("context_id", uint(contextID))),
+			DebugLogger(), /*.
+		With(debuglog.Uint("context_id", uint(contextID))),*/
 	}
 }
 

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -87,8 +87,8 @@ func (ctx *corazaPlugin) NewHttpContext(contextID uint32) types.HttpContext {
 		// TODO(jcchavezs): figure out how/when enable/disable metrics
 		metrics: ctx.metrics,
 		logger: ctx.waf.NewTransaction().
-			DebugLogger(), /*.
-		With(debuglog.Uint("context_id", uint(contextID))),*/
+			DebugLogger().
+			With(debuglog.Uint("context_id", uint(contextID))),
 	}
 }
 

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -514,13 +514,13 @@ func retrieveAddressInfo(logger debuglog.Logger, target string) (string, int) {
 	var targetPort int
 	targetAddressRaw, err := proxywasm.GetProperty([]string{target, "address"})
 	if err != nil {
-		logger.Warn().
+		logger.Debug().
 			Err(err).
 			Msg(fmt.Sprintf("Failed to get %s address", target))
 	} else {
 		targetIP, targetPortStr, err = net.SplitHostPort(string(targetAddressRaw))
 		if err != nil {
-			logger.Warn().
+			logger.Debug().
 				Err(err).
 				Msg(fmt.Sprintf("Failed to parse %s address", target))
 		}
@@ -529,7 +529,7 @@ func retrieveAddressInfo(logger debuglog.Logger, target string) (string, int) {
 	if err == nil {
 		targetPort, err = parsePort(targetPortRaw)
 		if err != nil {
-			logger.Warn().
+			logger.Debug().
 				Err(err).
 				Msg(fmt.Sprintf("Failed to parse %s port", target))
 		}
@@ -538,7 +538,7 @@ func retrieveAddressInfo(logger debuglog.Logger, target string) (string, int) {
 		// Mostly useful for proxies other than Envoy
 		targetPort, err = strconv.Atoi(targetPortStr)
 		if err != nil {
-			logger.Warn().
+			logger.Debug().
 				Err(err).
 				Msg(fmt.Sprintf("Failed to get %s port", target))
 

--- a/wasmplugin/plugin_test.go
+++ b/wasmplugin/plugin_test.go
@@ -6,7 +6,7 @@ package wasmplugin
 import (
 	"testing"
 
-	"github.com/corazawaf/coraza/v3/debuglogger"
+	"github.com/corazawaf/coraza/v3/debuglog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
@@ -62,7 +62,7 @@ func TestRetrieveAddressInfo(t *testing.T) {
 						require.NoError(t, err)
 					}
 
-					targetIP, port := retrieveAddressInfo(debuglogger.Nop(), target)
+					targetIP, port := retrieveAddressInfo(debuglog.Nop(), target)
 					assert.Equal(t, tCase.expectedTargetIP, targetIP)
 					assert.Equal(t, tCase.expectedPort, port)
 

--- a/wasmplugin/plugin_test.go
+++ b/wasmplugin/plugin_test.go
@@ -6,6 +6,7 @@ package wasmplugin
 import (
 	"testing"
 
+	"github.com/corazawaf/coraza/v3/debuglogger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
@@ -61,7 +62,7 @@ func TestRetrieveAddressInfo(t *testing.T) {
 						require.NoError(t, err)
 					}
 
-					targetIP, port := retrieveAddressInfo(target)
+					targetIP, port := retrieveAddressInfo(debuglogger.Nop(), target)
 					assert.Equal(t, tCase.expectedTargetIP, targetIP)
 					assert.Equal(t, tCase.expectedPort, port)
 

--- a/wasmplugin/rules/ftw-config.conf
+++ b/wasmplugin/rules/ftw-config.conf
@@ -1,11 +1,13 @@
 # Overrides default SecResponseBodyMimeType in order to add application/json (httpbin response Content-Type)
 SecResponseBodyMimeType text/plain text/html text/xml application/json
 # crs-setup.conf.example defaults SecAction only for phase 1 and 2.
-# Adding logs for phase 3 and 4 otherwise go-ftw is not able to detected the triggered rules
+# Adding logs for phase 3, 4 and 5 otherwise go-ftw is not able to detected the triggered rules
 SecDefaultAction "phase:3,log,auditlog,pass"
 SecDefaultAction "phase:4,log,auditlog,pass"
+SecDefaultAction "phase:5,log,auditlog,pass"
 SecDebugLogLevel 3
 
+# Rule 900005 from https://github.com/coreruleset/coreruleset/blob/v4.0/dev/tests/regression/README.md#requirements
 # By default rule 900340 is commented, therefore max_file_size is added to 900005 in order to test 920400-* rules
 SecAction "id:900005,\
   phase:1,\
@@ -13,7 +15,7 @@ SecAction "id:900005,\
   pass,\
   ctl:ruleEngine=DetectionOnly,\
   ctl:ruleRemoveById=910000,\
-  setvar:tx.paranoia_level=4,\
+  setvar:tx.blocking_paranoia_level=4,\
   setvar:tx.crs_validate_utf8_encoding=1,\
   setvar:tx.arg_name_length=100,\
   setvar:tx.arg_length=400,\


### PR DESCRIPTION
Clone of https://github.com/corazawaf/coraza-proxy-wasm/pull/164, pointing to main branch. 

---------------

In order to make https://github.com/corazawaf/coraza/pull/684 work, it is needed to:
- update `tx.paranoia_level outdated` CRS variable into `blocking_paranoia_level`
- add `SecDefaultAction “phase:5,log,auditlog,pass` otherwise correlation rules executed at phase 5 are not logged and ftw is not able to detect that these rules have been triggered.
Please refer to the upstream PRs for details: https://github.com/corazawaf/coraza/pull/684