### PR TITLE
fix: relaxes local response validation

### DIFF
--- a/example/envoy-config.yaml
+++ b/example/envoy-config.yaml
@@ -21,6 +21,12 @@ static_resources:
                 stat_prefix: ingress_http
                 codec_type: auto
                 route_config:
+                  # A custom response header is added for e2e testing purposes. A local response, triggered by an interruption,
+                  # has to allow custom added headers like this. See https://github.com/corazawaf/coraza-proxy-wasm/pull/172
+                  response_headers_to_add:
+                    - header: 
+                        key: "custom_header"
+                        value: "custom_value"
                   virtual_hosts:
                     - name: local_route
                       domains:


### PR DESCRIPTION
Based on some reports ( see https://github.com/corazawaf/coraza/discussions/594, https://github.com/corazawaf/coraza-proxy-wasm/issues/171#issuecomment-1508428211 and [here](https://owasp.slack.com/archives/C02BXH135AT/p1678237973291379)) the current local response validation based on enforcing that only one header is returned back from a local response is too strict.
It leads to an `Interruption already handled, unexpected local response` error, and the request remains hanging until timeout.

This PR proposes to relax it by:
- Checking it is  an `endOfStream` (no body response) 
- Checking the status is coherent with the status requested by the interruption.

As I wrote in the comments, it would be possible to clean up unexpected headers to reduce even more possible leaks, open to opinions about it