### PR TITLE
feat: add ReloadExample to easily reload the example when testing WASM

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ FTW_INCLUDE=920410 go run mage.go ftw
 
 ## Example: Spinning up the coraza-wasm-filter for manual tests
 
-Once the filter is built, via the commands `mage runExample` and `mage teardownExample` you can spin up and tear down the test environment. Envoy with the coraza-wasm filter will be reachable at `localhost:8080`. The filter is configured with the CRS loaded working in Anomaly Scoring mode. For details and locally tweaking the configuration refer to [@demo-conf](./wasmplugin/rules/coraza-demo.conf) and [@crs-setup-demo-conf](./wasmplugin/rules/crs-setup-demo.conf).
+Once the filter is built, via the commands `mage runExample`, `mage reloadExample`, and `mage teardownExample` you can spin up, test, and tear down the test environment. Envoy with the coraza-wasm filter will be reachable at `localhost:8080`. The filter is configured with the CRS loaded working in Anomaly Scoring mode. For details and locally tweaking the configuration refer to [@demo-conf](./wasmplugin/rules/coraza-demo.conf) and [@crs-setup-demo-conf](./wasmplugin/rules/crs-setup-demo.conf).
 In order to monitor envoy logs while performing requests you can run:
 
 - Envoy logs: `docker-compose -f ./example/docker-compose.yml logs -f envoy-logs`.

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -233,6 +233,7 @@ func TeardownExample() error {
 	return sh.RunV("docker-compose", "--file", "example/docker-compose.yml", "down")
 }
 
+// ReloadExample reload the test environment (container) in case of envoy or wasm update. Requires docker-compose
 func ReloadExample() error {
 	return sh.RunV("docker-compose", "--file", "example/docker-compose.yml", "restart")
 }

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -233,6 +233,10 @@ func TeardownExample() error {
 	return sh.RunV("docker-compose", "--file", "example/docker-compose.yml", "down")
 }
 
+func ReloadExample() error {
+	return sh.RunV("docker-compose", "--file", "example/docker-compose.yml", "restart")
+}
+
 var Default = Build
 
 func patchWasm(inPath, outPath string, initialPages int) error {


### PR DESCRIPTION
add ReloadExample that runs docker-compose reload. This help speeds up the development process since we don't need to teardown & up back the container.