### PR TITLE
avoids running response body in http done if interruption happened

### DIFF
--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -465,9 +465,10 @@ func (ctx *httpContext) OnHttpStreamDone() {
 	defer logTime("OnHttpStreamDone", currentTime())
 	tx := ctx.tx
 
-	if !tx.IsRuleEngineOff() {
+	if !tx.IsRuleEngineOff() && !ctx.interruptedAt.isInterrupted() {
 		// Responses without body won't call OnHttpResponseBody, but there are rules in the response body
-		// phase that still need to be executed. If they haven't been executed yet, now is the time.
+		// phase that still need to be executed. If they haven't been executed yet, and there has not been a previous
+		// interruption, now is the time.
 		if !ctx.processedResponseBody {
 			ctx.processedResponseBody = true
 			_, err := tx.ProcessResponseBody()


### PR DESCRIPTION
Fixes https://github.com/corazawaf/coraza-proxy-wasm/issues/181
Even if an http request is interrupted by a Coraza interruption that triggers a local response, the callback [OnHttpStreamDone](https://github.com/corazawaf/coraza-proxy-wasm/blob/main/wasmplugin/plugin.go#LL464C25-L464C41) is still called and consequently, the logic that runs `ProcessResponseBody` if it has not already been done.
This PR proposes to avoid the described logic if an interruption already happened.