### PR TITLE
feat: introducing dynamic WAF rules based on authority header

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,14 @@ In order to run the coraza-proxy-wasm we need to spin up an envoy configuration 
                         "@type": "type.googleapis.com/google.protobuf.StringValue"
                         value: |
                         {
-                            "rules": [
-                                "SecDebugLogLevel 9",
-                                "SecRuleEngine On",
-                                "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""
-                            ]
+                            "directives_map": {
+                                "default": [
+                                    "SecDebugLogLevel 9",
+                                    "SecRuleEngine On",
+                                    "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""
+                                ]
+                            },
+                            "default_directive": "default",
                         }
                     vm_config:
                         runtime: "envoy.wasm.runtime.v8"
@@ -84,7 +87,14 @@ configuration:
     "@type": "type.googleapis.com/google.protobuf.StringValue"
     value: |
     {
-        "rules": [ "SecDebugLogLevel 9", "SecRuleEngine On", "Include @owasp_crs/*.conf" ]
+        "directives_map": {
+            "default": [
+                "SecDebugLogLevel 9",
+                "SecRuleEngine On",
+                "Include @owasp_crs/*.conf"
+            ]
+        },
+        "default_directive": "default",
     }
 ```
 
@@ -95,7 +105,14 @@ configuration:
     "@type": "type.googleapis.com/google.protobuf.StringValue"
     value: |
     {
-        "rules": [ "SecDebugLogLevel 9", "SecRuleEngine On", "Include @owasp_crs/REQUEST-901-INITIALIZATION.conf" ]
+        "directives_map": {
+            "default": [
+                "SecDebugLogLevel 9",
+                "SecRuleEngine On",
+                "Include @owasp_crs/REQUEST-901-INITIALIZATION.conf"
+            ]
+        },
+        "default_directive": "default",
     }
 ```
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - --log-level
       - info
       - --component-log-level
-      - wasm:trace
+      - wasm:debug
       - --log-format [%Y-%m-%d %T.%f][%t][%l][%n] [%g:%#] %v
       - --log-path
       - /home/envoy/logs/envoy.log

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - --log-level
       - info
       - --component-log-level
-      - wasm:debug
+      - wasm:trace
       - --log-format [%Y-%m-%d %T.%f][%t][%l][%n] [%g:%#] %v
       - --log-path
       - /home/envoy/logs/envoy.log

--- a/example/envoy-config.yaml
+++ b/example/envoy-config.yaml
@@ -62,7 +62,7 @@ static_resources:
                                     "SecDefaultAction \"phase:5,log,auditlog,pass\"",
                                     "SecDebugLogLevel 3",
                                     "Include @owasp_crs/*.conf",
-                                    "SecRule REQUEST_URI \"@streq /global\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
+                                    "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
                                   ],
                                   "rs2": [
                                     "Include @demo-conf",
@@ -72,7 +72,7 @@ static_resources:
                                     "SecDefaultAction \"phase:5,log,auditlog,pass\"",
                                     "SecDebugLogLevel 3",
                                     "Include @owasp_crs/*.conf",
-                                    "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
+                                    "SecRule REQUEST_URI \"@streq /example\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
                                   ]
                               },
                               "default_ruleset": "rs1",

--- a/example/envoy-config.yaml
+++ b/example/envoy-config.yaml
@@ -53,7 +53,7 @@ static_resources:
                           "@type": "type.googleapis.com/google.protobuf.StringValue"
                           value: |
                             {
-                              "rulesets": {
+                              "directives_map": {
                                   "rs1": [
                                     "Include @demo-conf",
                                     "Include @crs-setup-demo-conf",
@@ -75,12 +75,12 @@ static_resources:
                                     "SecRule REQUEST_URI \"@streq /example\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
                                   ]
                               },
-                              "default_ruleset": "rs1",
+                              "default_directive": "rs1",
                               "metric_labels": {
                                 "owner": "coraza",
                                 "identifier": "global"
                               },
-                              "per_authority_ruleset":{
+                              "per_authority_directives":{
                                   "foo.example.com":"rs2",
                                   "bar.example.com":"rs2"
                               }

--- a/example/envoy-config.yaml
+++ b/example/envoy-config.yaml
@@ -10,6 +10,8 @@ stats_config:
       regex: "(_identifier=([0-9a-z.:]+))"
     - tag_name: owner
       regex: "(_owner=([0-9a-z.:]+))"
+    - tag_name: authority
+      regex: "(_authority=([0-9a-z.:]+))"
 
 static_resources:
   listeners:
@@ -51,19 +53,36 @@ static_resources:
                           "@type": "type.googleapis.com/google.protobuf.StringValue"
                           value: |
                             {
-                              "rules": [
-                                "Include @demo-conf",
-                                "Include @crs-setup-demo-conf",
-                                "SecDefaultAction \"phase:3,log,auditlog,pass\"",
-                                "SecDefaultAction \"phase:4,log,auditlog,pass\"",
-                                "SecDefaultAction \"phase:5,log,auditlog,pass\"",
-                                "SecDebugLogLevel 3",
-                                "Include @owasp_crs/*.conf",
-                                "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
-                              ],
+                              "rulesets": {
+                                  "rs1": [
+                                    "Include @demo-conf",
+                                    "Include @crs-setup-demo-conf",
+                                    "SecDefaultAction \"phase:3,log,auditlog,pass\"",
+                                    "SecDefaultAction \"phase:4,log,auditlog,pass\"",
+                                    "SecDefaultAction \"phase:5,log,auditlog,pass\"",
+                                    "SecDebugLogLevel 3",
+                                    "Include @owasp_crs/*.conf",
+                                    "SecRule REQUEST_URI \"@streq /global\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
+                                  ],
+                                  "rs2": [
+                                    "Include @demo-conf",
+                                    "Include @crs-setup-demo-conf",
+                                    "SecDefaultAction \"phase:3,log,auditlog,pass\"",
+                                    "SecDefaultAction \"phase:4,log,auditlog,pass\"",
+                                    "SecDefaultAction \"phase:5,log,auditlog,pass\"",
+                                    "SecDebugLogLevel 3",
+                                    "Include @owasp_crs/*.conf",
+                                    "SecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\" \nSecRule REQUEST_BODY \"@rx maliciouspayload\" \"id:102,phase:2,t:lowercase,deny\" \nSecRule RESPONSE_HEADERS::status \"@rx 406\" \"id:103,phase:3,t:lowercase,deny\" \nSecRule RESPONSE_BODY \"@contains responsebodycode\" \"id:104,phase:4,t:lowercase,deny\""
+                                  ]
+                              },
+                              "default_ruleset": "rs1",
                               "metric_labels": {
                                 "owner": "coraza",
                                 "identifier": "global"
+                              },
+                              "per_authority_ruleset":{
+                                  "foo.example.com":"rs2",
+                                  "bar.example.com":"rs2"
                               }
                             }
                         vm_config:

--- a/ftw/envoy-config.yaml
+++ b/ftw/envoy-config.yaml
@@ -46,7 +46,7 @@ static_resources:
                               },
                               "default_directive": "default",
                               "metric_labels": {},
-                              "per_authority_directives":{}
+                              "per_authority_directives": {}
                             }
                         vm_config:
                           runtime: "envoy.wasm.runtime.v8"

--- a/ftw/envoy-config.yaml
+++ b/ftw/envoy-config.yaml
@@ -36,12 +36,17 @@ static_resources:
                           # NB: inline rules order matter. Some ftw-config rules override the coraza-recommended default ones.
                           value: |
                             {
-                              "rules": [
-                                "Include @recommended-conf",
-                                "Include @ftw-conf",
-                                "Include @crs-setup-conf",
-                                "Include @owasp_crs/*.conf"
-                              ]
+                              "rulesets": {
+                                  "default": [
+                                    "Include @recommended-conf",
+                                    "Include @ftw-conf",
+                                    "Include @crs-setup-conf",
+                                    "Include @owasp_crs/*.conf"
+                                  ]
+                              },
+                              "default_ruleset": "default",
+                              "metric_labels": {},
+                              "per_authority_ruleset":{}
                             }
                         vm_config:
                           runtime: "envoy.wasm.runtime.v8"

--- a/ftw/envoy-config.yaml
+++ b/ftw/envoy-config.yaml
@@ -36,7 +36,7 @@ static_resources:
                           # NB: inline rules order matter. Some ftw-config rules override the coraza-recommended default ones.
                           value: |
                             {
-                              "rulesets": {
+                              "directives_map": {
                                   "default": [
                                     "Include @recommended-conf",
                                     "Include @ftw-conf",
@@ -44,9 +44,9 @@ static_resources:
                                     "Include @owasp_crs/*.conf"
                                   ]
                               },
-                              "default_ruleset": "default",
+                              "default_directive": "default",
                               "metric_labels": {},
-                              "per_authority_ruleset":{}
+                              "per_authority_directives":{}
                             }
                         vm_config:
                           runtime: "envoy.wasm.runtime.v8"

--- a/main_test.go
+++ b/main_test.go
@@ -423,7 +423,7 @@ func TestLifecycle(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				conf := `{}`
 				if inlineRules := strings.TrimSpace(tt.inlineRules); inlineRules != "" {
-					conf = fmt.Sprintf(`{"rules": ["%s"]}`, inlineRules)
+					conf = fmt.Sprintf(`{"rulesets": {"default": ["%s"]}, "default_ruleset": "default"}`, inlineRules)
 				}
 				opt := proxytest.
 					NewEmulatorOption().
@@ -651,7 +651,7 @@ func TestEmptyBody(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{ "rules": [ "SecRequestBodyAccess On", "SecResponseBodyAccess On" ] }`))
+			WithPluginConfiguration([]byte(`{"rulesets": {"default": [ "SecRequestBodyAccess On", "SecResponseBodyAccess On" ]}, "default_ruleset": "default"}`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()
@@ -740,11 +740,7 @@ func TestLogError(t *testing.T) {
 		for _, tc := range tests {
 			tt := tc
 			t.Run(fmt.Sprintf("severity %d", tt.severity), func(t *testing.T) {
-				conf := fmt.Sprintf(`
-{
-	"rules" : ["SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""]
-}
-`, tt.severity)
+				conf := fmt.Sprintf(`{"rulesets": {"default": ["SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""]}, "default_ruleset": "default"}`, tt.severity)
 
 				opt := proxytest.
 					NewEmulatorOption().
@@ -772,7 +768,8 @@ func TestParseCRS(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{ "rules": [ "Include @ftw-conf", "Include @recommended-conf", "Include @crs-setup-conf", "Include @owasp_crs/*.conf" ] }`))
+			WithPluginConfiguration([]byte(`{"rulesets": {"default": [ "Include @ftw-conf", "Include @recommended-conf", "Include @crs-setup-conf", "Include @owasp_crs/*.conf" ]}, "default_ruleset": "default"}`))
+			
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()
@@ -842,7 +839,7 @@ SecRuleEngine On\nSecRule REQUEST_URI \"@streq /hello\" \"id:101,phase:4,t:lower
 
 			t.Run(tt.name, func(t *testing.T) {
 				conf := fmt.Sprintf(`
-					{ "rules": ["%s"] }
+					{"rulesets": {"default": ["%s"]}, "default_ruleset": "default"}
 				`, strings.TrimSpace(tt.rules))
 				opt := proxytest.
 					NewEmulatorOption().
@@ -949,7 +946,7 @@ func TestRetrieveAddressInfo(t *testing.T) {
 
 				conf := `{}`
 				if inlineRules := strings.TrimSpace(inlineRules); inlineRules != "" {
-					conf = fmt.Sprintf(`{"rules": ["%s"]}`, inlineRules)
+					conf = fmt.Sprintf(`{"rulesets": {"default": ["%s"]}, "default_ruleset": "default"}`, inlineRules)
 				}
 				t.Run(tt.name, func(t *testing.T) {
 					opt := proxytest.
@@ -1012,7 +1009,7 @@ func TestParseServerName(t *testing.T) {
 
 			conf := `{}`
 			if inlineRules := strings.TrimSpace(inlineRules); inlineRules != "" {
-				conf = fmt.Sprintf(`{"rules": ["%s"]}`, inlineRules)
+				conf = fmt.Sprintf(`{"rulesets": {"default": ["%s"]}, "default_ruleset": "default"}`, inlineRules)
 			}
 			t.Run(name, func(t *testing.T) {
 				opt := proxytest.

--- a/main_test.go
+++ b/main_test.go
@@ -769,7 +769,6 @@ func TestParseCRS(t *testing.T) {
 			NewEmulatorOption().
 			WithVMContext(vm).
 			WithPluginConfiguration([]byte(`{"rulesets": {"default": [ "Include @ftw-conf", "Include @recommended-conf", "Include @crs-setup-conf", "Include @owasp_crs/*.conf" ]}, "default_ruleset": "default"}`))
-			
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()

--- a/main_test.go
+++ b/main_test.go
@@ -421,9 +421,9 @@ func TestLifecycle(t *testing.T) {
 			tt := tc
 
 			t.Run(tt.name, func(t *testing.T) {
-				conf := `{"rulesets": {"default": []}, "default_ruleset": "default"}`
+				conf := `{"directives_map": {"default": []}, "default_directive": "default"}`
 				if inlineRules := strings.TrimSpace(tt.inlineRules); inlineRules != "" {
-					conf = fmt.Sprintf(`{"rulesets": {"default": ["%s"]}, "default_ruleset": "default"}`, inlineRules)
+					conf = fmt.Sprintf(`{"directives_map": {"default": ["%s"]}, "default_directive": "default"}`, inlineRules)
 				}
 				opt := proxytest.
 					NewEmulatorOption().
@@ -587,7 +587,7 @@ func TestBadRequest(t *testing.T) {
 		for _, tc := range tests {
 			tt := tc
 			t.Run(tt.name, func(t *testing.T) {
-				conf := `{"rulesets": {"default": []}, "default_ruleset": "default"}`
+				conf := `{"directives_map": {"default": []}, "default_directive": "default"}`
 				opt := proxytest.
 					NewEmulatorOption().
 					WithVMContext(vm).
@@ -636,7 +636,7 @@ func TestBadResponse(t *testing.T) {
 		for _, tc := range tests {
 			tt := tc
 			t.Run(tt.name, func(t *testing.T) {
-				conf := `{"rulesets": {"default": []}, "default_ruleset": "default"}`
+				conf := `{"directives_map": {"default": []}, "default_directive": "default"}`
 				opt := proxytest.
 					NewEmulatorOption().
 					WithVMContext(vm).
@@ -666,7 +666,7 @@ func TestEmptyBody(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{"rulesets": {"default": [ "SecRequestBodyAccess On", "SecResponseBodyAccess On" ]}, "default_ruleset": "default"}`))
+			WithPluginConfiguration([]byte(`{"directives_map": {"default": [ "SecRequestBodyAccess On", "SecResponseBodyAccess On" ]}, "default_directive": "default"}`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()
@@ -761,7 +761,7 @@ func TestLogError(t *testing.T) {
 		for _, tc := range tests {
 			tt := tc
 			t.Run(fmt.Sprintf("severity %d", tt.severity), func(t *testing.T) {
-				conf := fmt.Sprintf(`{"rulesets": {"default": ["SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""]}, "default_ruleset": "default"}`, tt.severity)
+				conf := fmt.Sprintf(`{"directives_map": {"default": ["SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:%d,msg:'%%{MATCHED_VAR}',pass,t:none\""]}, "default_directive": "default"}`, tt.severity)
 
 				opt := proxytest.
 					NewEmulatorOption().
@@ -789,7 +789,7 @@ func TestParseCRS(t *testing.T) {
 		opt := proxytest.
 			NewEmulatorOption().
 			WithVMContext(vm).
-			WithPluginConfiguration([]byte(`{"rulesets": {"default": [ "Include @ftw-conf", "Include @recommended-conf", "Include @crs-setup-conf", "Include @owasp_crs/*.conf" ]}, "default_ruleset": "default"}`))
+			WithPluginConfiguration([]byte(`{"directives_map": {"default": [ "Include @ftw-conf", "Include @recommended-conf", "Include @crs-setup-conf", "Include @owasp_crs/*.conf" ]}, "default_directive": "default"}`))
 
 		host, reset := proxytest.NewHostEmulator(opt)
 		defer reset()
@@ -859,7 +859,7 @@ SecRuleEngine On\nSecRule REQUEST_URI \"@streq /hello\" \"id:101,phase:4,t:lower
 
 			t.Run(tt.name, func(t *testing.T) {
 				conf := fmt.Sprintf(`
-					{"rulesets": {"default": ["%s"]}, "default_ruleset": "default"}
+					{"directives_map": {"default": ["%s"]}, "default_directive": "default"}
 				`, strings.TrimSpace(tt.rules))
 				opt := proxytest.
 					NewEmulatorOption().
@@ -967,7 +967,7 @@ func TestRetrieveAddressInfo(t *testing.T) {
 
 				conf := `{}`
 				if inlineRules := strings.TrimSpace(inlineRules); inlineRules != "" {
-					conf = fmt.Sprintf(`{"rulesets": {"default": ["%s"]}, "default_ruleset": "default"}`, inlineRules)
+					conf = fmt.Sprintf(`{"directives_map": {"default": ["%s"]}, "default_directive": "default"}`, inlineRules)
 				}
 				t.Run(tt.name, func(t *testing.T) {
 					opt := proxytest.
@@ -1030,7 +1030,7 @@ func TestParseServerName(t *testing.T) {
 
 			conf := `{}`
 			if inlineRules := strings.TrimSpace(inlineRules); inlineRules != "" {
-				conf = fmt.Sprintf(`{"rulesets": {"default": ["%s"]}, "default_ruleset": "default"}`, inlineRules)
+				conf = fmt.Sprintf(`{"directives_map": {"default": ["%s"]}, "default_directive": "default"}`, inlineRules)
 			}
 			t.Run(name, func(t *testing.T) {
 				opt := proxytest.

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -33,7 +33,6 @@ func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
 	}
 
 	jsonData := gjson.ParseBytes(data)
-
 	config.directivesMap = make(DirectivesMap)
 	jsonData.Get("directives_map").ForEach(func(key, value gjson.Result) bool {
 		directiveName := key.String()

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -79,16 +79,19 @@ func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
 		}
 	}
 
-	rules := jsonData.Get("rules")
-	if rules.Exists() && len(config.directivesMap) == 0 {
-		config.defaultDirective = "default"
+	if len(config.directivesMap) == 0 {
+		rules := jsonData.Get("rules")
 
-		var directive []string
-		rules.ForEach(func(_, value gjson.Result) bool {
-			directive = append(directive, value.String())
-			return true
-		})
-		config.directivesMap["default"] = directive
+		if rules.Exists() {
+			config.defaultDirective = "default"
+
+			var directive []string
+			rules.ForEach(func(_, value gjson.Result) bool {
+				directive = append(directive, value.String())
+				return true
+			})
+			config.directivesMap["default"] = directive
+		}
 	}
 
 	return config, nil

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -21,7 +21,7 @@ type pluginConfiguration struct {
 type RuleSets map[string][]string
 
 func (rs RuleSets) Exists(name string) bool {
-	for key, _ := range rs {
+	for key := range rs {
 		if key == name {
 			return true
 		}

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -79,5 +79,17 @@ func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
 		}
 	}
 
+	rules := jsonData.Get("rules")
+	if rules.Exists() && len(config.directivesMap) == 0 {
+		config.defaultDirective = "default"
+
+		var directive []string
+		rules.ForEach(func(_, value gjson.Result) bool {
+			directive = append(directive, value.String())
+			return true
+		})
+		config.directivesMap["default"] = directive
+	}
+
 	return config, nil
 }

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -12,8 +12,22 @@ import (
 
 // pluginConfiguration is a type to represent an example configuration for this wasm plugin.
 type pluginConfiguration struct {
-	rules        []string
-	metricLabels map[string]string
+	ruleSets             RuleSets
+	metricLabels         map[string]string
+	defaultRuleSet       string
+	perAuthorityRuleSets map[string]string
+}
+
+type RuleSets map[string][]string
+
+func (rs RuleSets) Exists(name string) bool {
+	for key, _ := range rs {
+		if key == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
@@ -29,8 +43,21 @@ func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
 	}
 
 	jsonData := gjson.ParseBytes(data)
-	jsonData.Get("rules").ForEach(func(_, rule gjson.Result) bool {
-		config.rules = append(config.rules, rule.String())
+
+	config.ruleSets = make(RuleSets)
+	jsonData.Get("rulesets").ForEach(func(key, value gjson.Result) bool {
+		_, ok := config.ruleSets[key.String()]
+		if ok {
+			return true
+		}
+
+		var rule []string
+		value.ForEach(func(_, value gjson.Result) bool {
+			rule = append(rule, value.String())
+			return true
+		})
+
+		config.ruleSets[key.String()] = rule
 		return true
 	})
 
@@ -39,6 +66,27 @@ func parsePluginConfiguration(data []byte) (pluginConfiguration, error) {
 		config.metricLabels[key.String()] = value.String()
 		return true
 	})
+
+	defaultRuleSet := jsonData.Get("default_ruleset")
+	if defaultRuleSet.Exists() {
+		if !config.ruleSets.Exists(defaultRuleSet.String()) {
+			return config, fmt.Errorf("ruleset not found for default ruleset: %q", defaultRuleSet.String())
+		}
+
+		config.defaultRuleSet = defaultRuleSet.String()
+	}
+
+	config.perAuthorityRuleSets = make(map[string]string)
+	jsonData.Get("per_authority_ruleset").ForEach(func(key, value gjson.Result) bool {
+		config.perAuthorityRuleSets[key.String()] = value.String()
+		return true
+	})
+
+	for authority, ruleSetName := range config.perAuthorityRuleSets {
+		if !config.ruleSets.Exists(ruleSetName) {
+			return config, fmt.Errorf("ruleset not found for authority %s: %q", authority, ruleSetName)
+		}
+	}
 
 	return config, nil
 }

--- a/wasmplugin/config_test.go
+++ b/wasmplugin/config_test.go
@@ -24,10 +24,10 @@ func TestParsePluginConfiguration(t *testing.T) {
 			name:   "empty json",
 			config: "{}",
 			expectConfig: pluginConfiguration{
-				ruleSets:             RuleSets{},
-				metricLabels:         map[string]string{},
-				defaultRuleSet:       "",
-				perAuthorityRuleSets: map[string]string{},
+				directivesMap:          DirectivesMap{},
+				metricLabels:           map[string]string{},
+				defaultDirective:       "",
+				perAuthorityDirectives: map[string]string{},
 			},
 		},
 		{
@@ -39,78 +39,78 @@ func TestParsePluginConfiguration(t *testing.T) {
 			name: "inline",
 			config: `
 			{
-				"rulesets": {
+				"directives_map": {
 					"default": ["SecRuleEngine On"]
 				},
-				"default_ruleset": "default"
+				"default_directive": "default"
 			}
 			`,
 			expectConfig: pluginConfiguration{
-				ruleSets: RuleSets{
+				directivesMap: DirectivesMap{
 					"default": []string{"SecRuleEngine On"},
 				},
-				metricLabels:         map[string]string{},
-				defaultRuleSet:       "default",
-				perAuthorityRuleSets: map[string]string{},
+				metricLabels:           map[string]string{},
+				defaultDirective:       "default",
+				perAuthorityDirectives: map[string]string{},
 			},
 		},
 		{
 			name: "inline many entries",
 			config: `
 			{
-				"rulesets": {
+				"directives_map": {
 					"default": ["SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""]
 				},
-				"default_ruleset": "default"
+				"default_directive": "default"
 			}
 			`,
 			expectConfig: pluginConfiguration{
-				ruleSets: RuleSets{
+				directivesMap: DirectivesMap{
 					"default": []string{"SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""},
 				},
-				metricLabels:         map[string]string{},
-				defaultRuleSet:       "default",
-				perAuthorityRuleSets: map[string]string{},
+				metricLabels:           map[string]string{},
+				defaultDirective:       "default",
+				perAuthorityDirectives: map[string]string{},
 			},
 		},
 		{
 			name: "metrics label",
 			config: `
 			{
-				"rulesets": {
+				"directives_map": {
 					"default": ["SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""]
 				},
-				"default_ruleset": "default",
+				"default_directive": "default",
 				"metric_labels": {"owner": "coraza","identifier": "global"}
 			}
 			`,
 			expectConfig: pluginConfiguration{
-				ruleSets: RuleSets{
+				directivesMap: DirectivesMap{
 					"default": []string{"SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""},
 				},
 				metricLabels: map[string]string{
 					"owner":      "coraza",
 					"identifier": "global",
 				},
-				defaultRuleSet:       "default",
-				perAuthorityRuleSets: map[string]string{},
+				defaultDirective:       "default",
+				perAuthorityDirectives: map[string]string{},
 			},
 		},
 		{
-			name: "multiple rulesets",
+			name: "multiple directives_map",
 			config: `
 			{
-				"rulesets": {
+				"directives_map": {
 					"default": ["SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""],
 					"custom-01": ["SecRuleEngine On"],
 					"custom-02": ["SecRuleEngine On"]
 				},
-				"default_ruleset": "default",
+				"default_directive": "default",
 				"metric_labels": {"owner": "coraza","identifier": "global"}
 			}
 			`,
 			expectConfig: pluginConfiguration{
-				ruleSets: RuleSets{
+				directivesMap: DirectivesMap{
 					"default":   []string{"SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""},
 					"custom-02": []string{"SecRuleEngine On"},
 					"custom-01": []string{"SecRuleEngine On"},
@@ -119,29 +119,29 @@ func TestParsePluginConfiguration(t *testing.T) {
 					"owner":      "coraza",
 					"identifier": "global",
 				},
-				defaultRuleSet:       "default",
-				perAuthorityRuleSets: map[string]string{},
+				defaultDirective:       "default",
+				perAuthorityDirectives: map[string]string{},
 			},
 		},
 		{
-			name: "multiple rulesets with authority",
+			name: "multiple directives_map with authority",
 			config: `
 			{
-				"rulesets": {
+				"directives_map": {
 					"default": ["SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""],
 					"custom-01": ["SecRuleEngine On"],
 					"custom-02": ["SecRuleEngine On"]
 				},
-				"default_ruleset": "default",
+				"default_directive": "default",
 				"metric_labels": {"owner": "coraza","identifier": "global"},
-				"per_authority_ruleset": {
+				"per_authority_directives": {
 					"mydomain.com":"custom-01",
 					"mydomain2.com":"custom-02"
 				}
 			}
 			`,
 			expectConfig: pluginConfiguration{
-				ruleSets: RuleSets{
+				directivesMap: DirectivesMap{
 					"default":   []string{"SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""},
 					"custom-02": []string{"SecRuleEngine On"},
 					"custom-01": []string{"SecRuleEngine On"},
@@ -150,43 +150,43 @@ func TestParsePluginConfiguration(t *testing.T) {
 					"owner":      "coraza",
 					"identifier": "global",
 				},
-				defaultRuleSet: "default",
-				perAuthorityRuleSets: map[string]string{
+				defaultDirective: "default",
+				perAuthorityDirectives: map[string]string{
 					"mydomain.com":  "custom-01",
 					"mydomain2.com": "custom-02",
 				},
 			},
 		},
 		{
-			name: "default ruleset not found",
+			name: "default directive not found",
 			config: `
 			{
-				"rulesets": {
+				"directives_map": {
 					"default": ["SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""]
 				},
-				"default_ruleset": "foo"
+				"default_directive": "foo"
 			}
 			`,
-			expectErr: errors.New("ruleset not found for default ruleset: \"foo\""),
+			expectErr: errors.New("directive map not found for default directive: \"foo\""),
 		},
 		{
 			name: "per authority rule set not found",
 			config: `
 			{
-				"rulesets": {
+				"directives_map": {
 					"default": ["SecRuleEngine On", "Include @owasp_crs/*.conf\nSecRule REQUEST_URI \"@streq /admin\" \"id:101,phase:1,t:lowercase,deny\""],
 					"custom-01": ["SecRuleEngine On"],
 					"custom-02": ["SecRuleEngine On"]
 				},
-				"default_ruleset": "default",
+				"default_directive": "default",
 				"metric_labels": {"owner": "coraza","identifier": "global"},
-				"per_authority_ruleset": {
+				"per_authority_directives": {
 					"mydomain.com":"custom-01",
 					"mydomain2.com":"custom-03"
 				}
 			}
 			`,
-			expectErr: errors.New("ruleset not found for authority mydomain2.com: \"custom-03\""),
+			expectErr: errors.New("directive map not found for authority mydomain2.com: \"custom-03\""),
 		},
 	}
 
@@ -196,10 +196,10 @@ func TestParsePluginConfiguration(t *testing.T) {
 			assert.Equal(t, testCase.expectErr, err)
 
 			if testCase.expectErr == nil {
-				assert.Equal(t, testCase.expectConfig.ruleSets, cfg.ruleSets)
+				assert.Equal(t, testCase.expectConfig.directivesMap, cfg.directivesMap)
 				assert.Equal(t, testCase.expectConfig.metricLabels, cfg.metricLabels)
-				assert.Equal(t, testCase.expectConfig.defaultRuleSet, cfg.defaultRuleSet)
-				assert.Equal(t, testCase.expectConfig.perAuthorityRuleSets, cfg.perAuthorityRuleSets)
+				assert.Equal(t, testCase.expectConfig.defaultDirective, cfg.defaultDirective)
+				assert.Equal(t, testCase.expectConfig.perAuthorityDirectives, cfg.perAuthorityDirectives)
 			}
 		})
 	}


### PR DESCRIPTION
solve https://github.com/corazawaf/coraza-proxy-wasm/issues/180

**Proposal**
1. introducing a list of directives (directives_map), this list of directives_map will have its own transaction & logging object
2. ability to enable default directive(default_directive), if this is enabled, all requests will flow through WAF
3. ability to enable a specific directive per authority (per_authority_directives), this will completely replace the default directive for specific authority defined

| **default_directive** | **per_authority_directives** | Expectation |
|---|---|---|
| global_directive | "foo.example.com": "foo_directive" | 1. foo.example.com will implement foo_directive<br>2. any other authority will implement global_directive  |
| global_directive | N/A | 1. all traffic will implement global_directive  |
| N/A | "foo.example.com": "foo_directive" | 1. foo.example.com will implement foo_directive<br>2. ignore any other traffic |
| N/A | N/A | 1. ignore all traffic |