### PR TITLE
ci: Release job after tag creations

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,3 +136,39 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Cache WASM filter
+        # Cached only on tag creation
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+        id: cache-wasm-filter
+        uses: actions/cache@v3
+        with:
+          path: build/main.wasm
+          key: ${{ hashFiles('wasmplugin/**') }}
+
+  # Triggered only on tag creation
+  release:
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: build
+    name: Release
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - uses: actions/cache/restore@v3
+        id: cache-wasm-filter
+        with:
+          path: build/main.wasm
+          key: ${{ hashFiles('wasmplugin/**') }}
+          fail-on-cache-miss: true
+
+      - name: Create draft release
+        run: |
+          ls build
+          tag="${GITHUB_REF#refs/tags/}"
+          mv build/main.wasm build/coraza-proxy-wasm-${tag}.wasm
+          ./.github/workflows/release_notes.sh ${tag} > release-notes.txt
+          gh release create ${tag} --draft --notes-file release-notes.txt --title ${GITHUB_REF#refs/tags/} ./build/coraza-proxy-wasm-${tag}.wasm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,38 +137,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Cache WASM filter
-        # Cached only on tag creation
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-        id: cache-wasm-filter
-        uses: actions/cache@v3
-        with:
-          path: build/main.wasm
-          key: ${{ hashFiles('wasmplugin/**') }}
-
-  # Triggered only on tag creation
-  release:
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    needs: build
-    name: Release
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-
-      - uses: actions/cache/restore@v3
-        id: cache-wasm-filter
-        with:
-          path: build/main.wasm
-          key: ${{ hashFiles('wasmplugin/**') }}
-          fail-on-cache-miss: true
-
       - name: Create draft release
+        # Triggered only on tag creation
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         run: |
+          sudo apt install zip -y
           ls build
+          mv build/main.wasm build/coraza-proxy-wasm.wasm
           tag="${GITHUB_REF#refs/tags/}"
-          mv build/main.wasm build/coraza-proxy-wasm-${tag}.wasm
+          zip -j build/coraza-proxy-wasm-${tag}.zip build/coraza-proxy-wasm.wasm
           ./.github/workflows/release_notes.sh ${tag} > release-notes.txt
-          gh release create ${tag} --draft --notes-file release-notes.txt --title ${GITHUB_REF#refs/tags/} ./build/coraza-proxy-wasm-${tag}.wasm
+          gh release create ${tag} --draft --notes-file release-notes.txt --title ${GITHUB_REF#refs/tags/} ./build/coraza-proxy-wasm-${tag}.zip
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release_notes.sh
+++ b/.github/workflows/release_notes.sh
@@ -1,0 +1,42 @@
+#!/bin/sh -ue
+# Copyright The OWASP Coraza contributors
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# Highly inspired by https://github.com/tetratelabs/wazero/blob/main/.github/workflows/release_notes.sh
+#
+# This script generates the release notes for a specific release tag.
+# .github/workflows/release_notes.sh v1.3.0
+
+tag=$1
+prior_tag=$(git tag -l 'v*'|sed "/${tag}/,+10d"|tail -1)
+if [ -n "${prior_tag}" ]; then
+  range="${prior_tag}..${tag}"
+else
+  range=${tag}
+fi
+
+git config log.mailmap true
+changelog=$(git log --format='%h %s %aN, %(trailers:key=co-authored-by)' "${range}")
+
+# strip the v off the tag name more shell portable than ${tag:1}
+version=$(echo "${tag}" | cut -c2-100) || exit 1
+cat <<EOF
+coraza-proxy-wasm ${version}
+
+TODO: classify the below into up to 4 major headings and the rest as bulleted items in other changes
+The published release notes should only include the summary statement in this section.
+
+${changelog}
+
+## X packages
+
+Don't forget to cite who was involved and why
+
+## Other changes
+
+TODO: don't add trivial things like fixing spaces or non-concerns like build glitches
+
+* Z is now fixed thanks to Yogi Bear
+
+EOF


### PR DESCRIPTION
Closes https://github.com/corazawaf/coraza-proxy-wasm/issues/177.
This PR implements the release CI job. Only on tag creation:
- The build job executes one more step of caching `main.wasm` for the next job.
- Release is triggered after build, restores the cache and creates a draft release with the wasm file renamed as `coraza-proxy-wasm-${tag}.wasm` and an initial changelog template. 
Inspired by https://github.com/tetratelabs/wazero/blob/main/.github/workflows/release.yaml