### PR TITLE
fix: missbehaviour authority metrics

### DIFF
--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -246,6 +246,11 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 		if !exist {
 			return types.ActionContinue
 		}
+
+		_, ok := ctx.metricLabels["authority"]
+		if ok {
+			delete(ctx.metricLabels, "authority")
+		}
 	} else {
 		ctx.tx, exist = ctx.wafSets.getTx(wafDirectiveName)
 		if !exist {


### PR DESCRIPTION
fix https://github.com/corazawaf/coraza-proxy-wasm/issues/186

## Output
```bash
(⎈ |home-lab:istio-system) [3/05/23 | 8:29:49]
~ $ curl -s localhost:8082/stats/prometheus | grep waf
(⎈ |home-lab:istio-system) [3/05/23 | 8:29:52]
~ $ curl http://localhost:8080/admin -H 'Host: global'

(⎈ |home-lab:istio-system) [3/05/23 | 8:29:55]
~ $ curl -s localhost:8082/stats/prometheus | grep waf

# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 1
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 1
(⎈ |home-lab:istio-system) [3/05/23 | 8:29:57]
~ $ curl http://localhost:8080/example -H 'Host: foo.example.com'

(⎈ |home-lab:istio-system) [3/05/23 | 8:30:00]
~ $ curl -s localhost:8082/stats/prometheus | grep waf

# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza",authority="foo.example.com"} 1
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 1
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 2
(⎈ |home-lab:istio-system) [3/05/23 | 8:30:03]
~ $ curl http://localhost:8080/admin -H 'Host: global'

(⎈ |home-lab:istio-system) [3/05/23 | 8:30:05]
~ $ curl -s localhost:8082/stats/prometheus | grep waf

# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza",authority="foo.example.com"} 1
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 2
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 3
(⎈ |home-lab:istio-system) [3/05/23 | 8:30:08]
~ $ curl http://localhost:8080/example -H 'Host: foo.example.com'

(⎈ |home-lab:istio-system) [3/05/23 | 8:30:12]
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:03]
~ $ curl -s localhost:8082/stats/prometheus | grep waf
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:04]
~ $ curl http://localhost:8080/admin -H 'Host: global'
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:08]
~ $ curl -s localhost:8082/stats/prometheus | grep waf
# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 1
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 1
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:11]
~ $ curl http://localhost:8080/example -H 'Host: foo.example.com'
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:16]
~ $ curl -s localhost:8082/stats/prometheus | grep waf
# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza",authority="foo.example.com"} 1
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 1
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 2
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:20]
~ $ curl http://localhost:8080/admin -H 'Host: global'
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:24]
~ $ curl -s localhost:8082/stats/prometheus | grep waf
# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza",authority="foo.example.com"} 1
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 2
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 3
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:28]
~ $ curl http://localhost:8080/example -H 'Host: foo.example.com'
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:33]
~ $ curl -s localhost:8082/stats/prometheus | grep waf           
# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza",authority="foo.example.com"} 2
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 2
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 4
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:35]
~ $ curl http://localhost:8080/admin -H 'Host: global'
(⎈ |home-lab:istio-system) [3/05/23 | 8:36:40]
~ $ curl -s localhost:8082/stats/prometheus | grep waf
# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza",authority="foo.example.com"} 2
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 3
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 5
```