### PR TITLE
fix(ProcessResponseBody): Avoids multiple calls, discussion about OnHttpStreamDone call

### DIFF
--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -593,21 +593,6 @@ func (ctx *httpContext) OnHttpStreamDone() {
 	tx := ctx.tx
 
 	if tx != nil {
-		if !tx.IsRuleEngineOff() && !ctx.interruptedAt.isInterrupted() {
-			// Responses without body won't call OnHttpResponseBody, but there are rules in the response body
-			// phase that still need to be executed. If they haven't been executed yet, and there has not been a previous
-			// interruption, now is the time.
-			if !ctx.processedResponseBody {
-				ctx.processedResponseBody = true
-				_, err := tx.ProcessResponseBody()
-				if err != nil {
-					ctx.logger.Error().
-						Err(err).
-						Msg("Failed to process response body")
-				}
-			}
-		}
-
 		// ProcessLogging is still called even if RuleEngine is off for potential logs generated before the engine is turned off.
 		// Internally, if the engine is off, no log phase rules are evaluated
 		ctx.tx.ProcessLogging()


### PR DESCRIPTION
This PR aims to:
1. Address multiple calls of `ProcessResponseBody` happening when `SecResponseBodyAccess` is `off`. `OnHttpResponseBody` might be called multiple times, the call of `ProcessResponseBody` if the response body is not accessible was not followed by enabling the `processedResponseBody` boolean (and anticipated by the relative check).
   - Most likely it fixes https://github.com/corazawaf/coraza-proxy-wasm/issues/181#issuecomment-1540009474.
2. Discuss the usefulness of calling `ProcessResponseBody` during `OnHttpStreamDone()`. The concern has been raised here by @jcchavezs: https://github.com/corazawaf/coraza-proxy-wasm/pull/183#issuecomment-1528651275
   - During OnHttpStreamDone we can not enforce anymore any action, the interruption is indeed not even checked
   - I might only see some value in terms of triggering rules that might generate variables that will be logged, but it seems to be quite in conflict with the idea of optimizing the process and avoiding processing rules if we already know that we have to enforce a disruptive action (or that we can not do anything more)
   - The anomaly score would be further increased (if anything is found in the body), but again, it is a value that can just lead to the logs, being too late to enforce any action. It might even be quite misleading to log an anomaly score that has been computed after the point of actions enforcement
   - It has been introduced with https://github.com/corazawaf/coraza-proxy-wasm/commit/99466ec646c450949d8f335c12cc5b8f12c3338e, @anuraaga do you recall the reasoning that has been done that led to this call? 🙏. I added the remotion as a separate commit to easily revert it, the main point is to open a discussion around it :)
