### PR TITLE
chore(readme): clarifies project dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ Targets:
 * default target
 ```
 
+### Building requirements
+Building the filter requires:
+- [Go](https://go.dev/doc/install) 
+- [TinyGo](https://tinygo.org/getting-started/install/)
+
+Up to date required versions can be found looking at [`minGoVersion` and `tinygoMinorVersion` variables](./magefiles/magefile.go).
+
 ### Building the filter
 
-After having installed [TinyGo](https://tinygo.org/getting-started/install/) (The required version can be found looking at the [`tinygoMinorVersion`](./magefiles/magefile.go) variable), run:
 ```bash
 go run mage.go build
 ```

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Targets:
 
 ### Building the filter
 
+After having installed [TinyGo](https://tinygo.org/getting-started/install/) (The required version can be found looking at the [`tinygoMinorVersion`](./magefiles/magefile.go) variable), run:
 ```bash
 go run mage.go build
 ```


### PR DESCRIPTION
Fixes https://github.com/corazawaf/coraza-proxy-wasm/issues/195 explicitly stating that tinygo is required and providing a link to see the required version.