### PR TITLE
fix: authority retrieval by mapping per authority and not per directives name.

### DIFF
--- a/wasmplugin/config_test.go
+++ b/wasmplugin/config_test.go
@@ -250,18 +250,12 @@ func TestWAFMap(t *testing.T) {
 	err := wm.put("foo", w)
 	require.NoError(t, err)
 
-	t.Run("set nil default waf", func(t *testing.T) {
-		err = wm.setDefaultWAF(nil)
-		require.Error(t, err)
-	})
-
 	t.Run("get unexisting WAF with no default", func(t *testing.T) {
 		_, _, err := wm.getWAFOrDefault("bar")
 		require.Error(t, err)
 	})
 
-	err = wm.setDefaultWAF(w)
-	require.NoError(t, err)
+	wm.setDefaultWAF(w)
 
 	t.Run("get existing WAF", func(t *testing.T) {
 		expecteWAF, isDefault, err := wm.getWAFOrDefault("foo")

--- a/wasmplugin/config_test.go
+++ b/wasmplugin/config_test.go
@@ -250,8 +250,8 @@ func TestWAFMap(t *testing.T) {
 	err := wm.put("foo", w)
 	require.NoError(t, err)
 
-	t.Run("set unexisting default key", func(t *testing.T) {
-		err = wm.setDefaultKey("bar")
+	t.Run("set nil default waf", func(t *testing.T) {
+		err = wm.setDefaultWAF(nil)
 		require.Error(t, err)
 	})
 
@@ -260,7 +260,7 @@ func TestWAFMap(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	err = wm.setDefaultKey("foo")
+	err = wm.setDefaultWAF(w)
 	require.NoError(t, err)
 
 	t.Run("get existing WAF", func(t *testing.T) {

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -104,18 +104,13 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 
 	perAuthorityWAFs := newWAFMap(len(config.directivesMap))
 	for name, directives := range config.directivesMap {
-		var (
-			authorities     []string
-			isTheDefaultWAF bool
-		)
+		var authorities []string
 
 		// if the name of the directives is the default directives, we
 		// initialize the WAF despite the fact that it is not associated
 		// to any authority. This is because we need to initialize the
 		// default WAF for requests that don't belong to any authority.
-		if name == config.defaultDirectives {
-			isTheDefaultWAF = true
-		} else {
+		if name != config.defaultDirectives {
 			var directivesFound bool
 			authorities, directivesFound = directivesAuthoritiesMap[name]
 			if !directivesFound {
@@ -143,7 +138,10 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 			return types.OnPluginStartStatusFailed
 		}
 
-		if isTheDefaultWAF {
+		if len(authorities) == 0 {
+			// if no authorities are associated directly with this WAF
+			// but we still initialize it, it means this is the default
+			// one.
 			perAuthorityWAFs.setDefaultWAF(waf)
 		}
 

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -102,11 +102,12 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 	perAuthorityWAFs := newWAFMap(len(config.directivesMap))
 	for name, directives := range config.directivesMap {
 		var (
-			authorities         []string
-			shouldSetDefaultWAF bool
+			authorities     []string
+			isTheDefaultWAF bool
 		)
+
 		if name == config.defaultDirectives {
-			shouldSetDefaultWAF = true
+			isTheDefaultWAF = true
 		} else {
 			var directivesFound bool
 			authorities, directivesFound = directivesAuthoritiesMap[name]
@@ -135,15 +136,15 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 			return types.OnPluginStartStatusFailed
 		}
 
-		if shouldSetDefaultWAF {
+		if isTheDefaultWAF {
 			perAuthorityWAFs.setDefaultWAF(waf)
-		} else {
-			for _, authority := range authorities {
-				err = perAuthorityWAFs.put(authority, waf)
-				if err != nil {
-					proxywasm.LogCriticalf("Failed to register authority WAF: %v", err)
-					return types.OnPluginStartStatusFailed
-				}
+		}
+
+		for _, authority := range authorities {
+			err = perAuthorityWAFs.put(authority, waf)
+			if err != nil {
+				proxywasm.LogCriticalf("Failed to register authority WAF: %v", err)
+				return types.OnPluginStartStatusFailed
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/corazawaf/coraza-proxy-wasm/issues/198

In this PR I took a different approach compared to https://github.com/corazawaf/coraza-proxy-wasm/pull/199 to not to add another object and also avoiding initialization of WAFs that are not being used by any authority but **I borrowed the tests created in @zufardhiyaulhaq PR's which was awesome**. Thanks for that.