### PR TITLE
fix(ci): changes Coraza reference to main brach

### DIFF
--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Get last commit of coraza
         id: coraza-latest-commit
-        run: echo "value=$(gh api repos/corazawaf/coraza/commits/v3/dev -q .sha)" >> $GITHUB_OUTPUT
+        run: echo "value=$(gh api repos/corazawaf/coraza/commits/main -q .sha)" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Follows https://github.com/corazawaf/coraza/discussions/773 decision about renaming Coraza main branch from `v3/master` to `main`. Fixes Nightly Coraza Check.