### PR TITLE
ci: sets contents write permission to create draft releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     name: "Build (multiphase evaluation: ${{ matrix.multiphase_eval }})"
     runs-on: ubuntu-22.04
     permissions:
-      contents: read
+      contents: write
       packages: write
     strategy:
       matrix:


### PR DESCRIPTION
`contents` scope allows to modify repository's content, it should be the missing needed permission to make `Create Draft Release` step work. (see failing action: https://github.com/corazawaf/coraza-proxy-wasm/actions/runs/5221810741/jobs/9426707613#step:18:38)