### PR TITLE
Upgrade nottinygc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0
 	github.com/tidwall/gjson v1.14.4
-	github.com/wasilibs/nottinygc v0.2.0
+	github.com/wasilibs/nottinygc v0.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/wasilibs/go-libinjection v0.3.0 h1:X2zERL6bjRRPTnOWPI5CT6t1LMJNw7f+FZ
 github.com/wasilibs/go-libinjection v0.3.0/go.mod h1:pjrvsp+uswZLkflpghGhrgKpGEZlemqkLwKOJyIsvj4=
 github.com/wasilibs/go-re2 v1.1.0 h1:RF/qHrnaFRIYaxnDFIZ4I8cZJTU+wE9DkOHtEHOUA18=
 github.com/wasilibs/go-re2 v1.1.0/go.mod h1:9j8kG6X6t8KQoB9odr0+WEieocbZwbKUgTo8GjNUdV4=
-github.com/wasilibs/nottinygc v0.2.0 h1:cXz2Ac9bVMLkpuOlUlPQMWowjw0K2cOErXZOFdAj7yE=
-github.com/wasilibs/nottinygc v0.2.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=
+github.com/wasilibs/nottinygc v0.3.0 h1:0L1jsJ1MsyN5tdinmFbLfuEA0TnHRcqaBM9pDTJVJmU=
+github.com/wasilibs/nottinygc v0.3.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
 golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
 golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=


### PR DESCRIPTION
0.3.0 has support for TinyGo 0.28. Unfortunately, it seems this repo doesn't work with 0.28 since one of our codepaths seems to cause `fd_readdir` to be imported when updating... But anyways, getting the code ready to figure out a way to deal with that first