### PR TITLE
feat: uses memoization to decrease memory consumption.

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -193,6 +193,9 @@ func Build() error {
 	if os.Getenv("MEMSTATS") == "true" {
 		buildTags = append(buildTags, "memstats")
 	}
+	if os.Getenv("MEMOIZE_BUILDERS") != "false" {
+		buildTags = append(buildTags, "memoize_builders")
+	}
 
 	buildTagArg := fmt.Sprintf("-tags='%s'", strings.Join(buildTags, " "))
 

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -182,7 +182,11 @@ func Build() error {
 		return err
 	}
 
-	buildTags := []string{"custommalloc", "no_fs_access"}
+	buildTags := []string{
+		"custommalloc",     // https://github.com/wasilibs/nottinygc#usage
+		"no_fs_access",     // https://github.com/corazawaf/coraza#build-tags
+		"memoize_builders", // https://github.com/corazawaf/coraza#build-tags
+	}
 	// By default multiphase evaluation is enabled
 	if os.Getenv("MULTIPHASE_EVAL") != "false" {
 		buildTags = append(buildTags, "coraza.rule.multiphase_evaluation")
@@ -192,9 +196,6 @@ func Build() error {
 	}
 	if os.Getenv("MEMSTATS") == "true" {
 		buildTags = append(buildTags, "memstats")
-	}
-	if os.Getenv("MEMOIZE_BUILDERS") != "false" {
-		buildTags = append(buildTags, "memoize_builders")
 	}
 
 	buildTagArg := fmt.Sprintf("-tags='%s'", strings.Join(buildTags, " "))


### PR DESCRIPTION
This PR enables memoization of builders for `regex` and `aho-corasick` dictionaries to reduce memory consumption in deployments that launch several coraza instances (e.g. several authorities). For more context check https://github.com/corazawaf/coraza-caddy/issues/76