### PR TITLE
Adds back e2e against multiple Envoy images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,7 +71,12 @@ jobs:
         run: go run mage.go coverage
 
       - name: Run e2e tests
-        run: go run mage.go e2e
+        shell: bash
+        run: >
+          for image in $ENVOY_IMAGES; do
+              echo "Running e2e with Envoy image $image"
+              ENVOY_IMAGE=$image go run mage.go e2e
+          done
 
       - name: Run regression tests (ftw)
         run: go run mage.go ftw


### PR DESCRIPTION
Follows #224 addressing https://github.com/corazawaf/coraza-proxy-wasm/pull/224#discussion_r1317252495

Multiple Envoys images are being tested back in the CI:
```
Run for image in $ENVOY_IMAGES; do
Running e2e with Envoy image envoyproxy/envoy:v1.27-latest
Creating network "e2e_default" with the default driver
Pulling httpbin (mccutchen/go-httpbin:v2.9.0)...
v2.9.0: Pulling from mccutchen/go-httpbin
Digest: sha256:9fffd11a43051be0ed27556e09ad9dca0a341769c31ef4699c592ed2b24c6986
Status: Downloaded newer image for mccutchen/go-httpbin:v2.9.0
Pulling envoy (envoyproxy/envoy:v1.27-latest)...
v1.27-latest: Pulling from envoyproxy/envoy
Digest: sha256:3c607686b205188dd035e1a6f30b830ce4e2c1b0dfecac2ccf150796c29abf35
Status: Downloaded newer image for envoyproxy/envoy:v1.27-latest
[...]
[9/9] Running test: CRS malicious UA test (9[13](https://github.com/M4tteoP/coraza-proxy-wasm/actions/runs/6098711066/job/16549153387#step:9:14)100-6)
[Ok] Got expected status code 403
Stopping e2e_envoy_1   ... 
Stopping e2e_httpbin_1 ... 
[...]
Running e2e with Envoy image envoyproxy/envoy:v1.26-latest
[...]
Status: Downloaded newer image for envoyproxy/envoy:v1.26-latest
[...]
[9/9] Running test: CRS malicious UA test (913100-6)
[Ok] Got expected status code 403
[...]
Running e2e with Envoy image envoyproxy/envoy-dev:latest
Creating network "e2e_default" with the default driver
Pulling envoy (envoyproxy/envoy-dev:latest)...
[...]
Status: Downloaded newer image for envoyproxy/envoy-dev:latest
```