### PR TITLE
Update TinyGo to 0.29

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   GO_VERSION: '1.20'
-  TINYGO_VERSION: 0.28.1
+  TINYGO_VERSION: 0.29.0
   # Run e2e tests against latest two releases and latest dev
   ENVOY_IMAGES: >
     envoyproxy/envoy:v1.27-latest

--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   GO_VERSION: '1.20'
-  TINYGO_VERSION: 0.28.1
+  TINYGO_VERSION: 0.29.0
 
 jobs:
   test:

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -20,7 +20,7 @@ import (
 )
 
 var minGoVersion = "1.20"
-var tinygoMinorVersion = "0.28"
+var tinygoMinorVersion = "0.29"
 var addLicenseVersion = "04bfe4ee9ca5764577b029acc6a1957fd1997153" // https://github.com/google/addlicense
 var golangCILintVer = "v1.54.2"                                    // https://github.com/golangci/golangci-lint/releases
 var gosImportsVer = "v0.3.1"                                       // https://github.com/rinchsan/gosimports/releases/tag/v0.3.1


### PR DESCRIPTION
Was trying to build and noticed my TinyGo was too new. Looks like there is no issue in going ahead and updating