### PR TITLE
Updates to latest tinygo and coraza-wasilibs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ on:
 
 env:
   GO_VERSION: '1.20'
-  TINYGO_VERSION: 0.29.0
+  TINYGO_VERSION: 0.30.0
   # Run e2e tests against latest two releases and latest dev
   ENVOY_IMAGES: >
     envoyproxy/envoy:v1.27-latest

--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   GO_VERSION: '1.20'
-  TINYGO_VERSION: 0.29.0
+  TINYGO_VERSION: 0.30.0
 
 jobs:
   test:

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/corazawaf/coraza-proxy-wasm
 go 1.20
 
 require (
-	github.com/corazawaf/coraza-wasilibs v0.0.0-20230620081031-05a5097dbea3
+	github.com/corazawaf/coraza-wasilibs v0.0.0-20231002095218-9dd6e48f7443
 	github.com/corazawaf/coraza/v3 v3.0.4
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0
@@ -18,12 +18,12 @@ require (
 	github.com/magefile/mage v1.15.0 // indirect
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20230725210150-fb29fc3c913e // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/tetratelabs/wazero v1.2.1 // indirect
+	github.com/tetratelabs/wazero v1.5.0 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	github.com/wasilibs/go-aho-corasick v0.5.0 // indirect
 	github.com/wasilibs/go-libinjection v0.4.0 // indirect
-	github.com/wasilibs/go-re2 v1.2.0 // indirect
+	github.com/wasilibs/go-re2 v1.4.0 // indirect
 	golang.org/x/net v0.15.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/corazawaf/coraza-wasilibs v0.0.0-20230620081031-05a5097dbea3 h1:c6INlbuM6RdeUU0ySzQsk6lzlqdGdm4GSQhN3qpcvkg=
-github.com/corazawaf/coraza-wasilibs v0.0.0-20230620081031-05a5097dbea3/go.mod h1:Ks3GxgMzwgVeo2nbVEPvmw94sOvJ+VjikPGLD5sNXUU=
+github.com/corazawaf/coraza-wasilibs v0.0.0-20231002095218-9dd6e48f7443 h1:36dTwNjieaDJB/AxPRUHGKCiCn8Bqpu25fb8OdrPemQ=
+github.com/corazawaf/coraza-wasilibs v0.0.0-20231002095218-9dd6e48f7443/go.mod h1:aMVO6E4TFAxXnPmyrrEoXVYeMDovq3IsKwuetAR38JE=
 github.com/corazawaf/coraza/v3 v3.0.4 h1:Llemgoh0hp2NggCwcWN8lNiV4Pfe+AWzf1oEcasT234=
 github.com/corazawaf/coraza/v3 v3.0.4/go.mod h1:3fTYjY5BZv3nezLpH6NAap0gr3jZfbQWUAu2GF17ET4=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=
@@ -27,8 +27,8 @@ github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PK
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0 h1:kS7BvMKN+FiptV4pfwiNX8e3q14evxAWkhYbxt8EI1M=
 github.com/tetratelabs/proxy-wasm-go-sdk v0.22.0/go.mod h1:qkW5MBz2jch2u8bS59wws65WC+Gtx3x0aPUX5JL7CXI=
-github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
-github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.5.0 h1:Yz3fZHivfDiZFUXnWMPUoiW7s8tC1sjdBtlJn08qYa0=
+github.com/tetratelabs/wazero v1.5.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/tidwall/gjson v1.17.0 h1:/Jocvlh98kcTfpN2+JzGQWQcqrPQwDrVEMApx/M5ZwM=
 github.com/tidwall/gjson v1.17.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -40,8 +40,8 @@ github.com/wasilibs/go-aho-corasick v0.5.0 h1:Y8G8eJ7usuC14sd93IxxnZH43K5Bz5C90a
 github.com/wasilibs/go-aho-corasick v0.5.0/go.mod h1:1XPgz4lvFZA+Ytd8vfeCoqnwy4CSe0MxnLfRQJVqpJM=
 github.com/wasilibs/go-libinjection v0.4.0 h1:dr1Y/kM/gmoA7eSfdf+CvCcmzwsz2jVYjNdakgladDU=
 github.com/wasilibs/go-libinjection v0.4.0/go.mod h1:zD7fNXKSaTKoSTmrfuP9Gc16alNEgwkZaHIeDDk3WWM=
-github.com/wasilibs/go-re2 v1.2.0 h1:EBE8PqqetncIYi4HyQiH3q73ZVWcrL2UATSm8+jL6Ng=
-github.com/wasilibs/go-re2 v1.2.0/go.mod h1:NdBnojD1uYA206Q0pBK/OKX12YZjIxg3fkvK75AbXIo=
+github.com/wasilibs/go-re2 v1.4.0 h1:Jp6BM8G/zajgY1BCQUm3i7oGMdR1gA5EBv87wGd2ysc=
+github.com/wasilibs/go-re2 v1.4.0/go.mod h1:hLzlKjEgON+17hWjikLx8hJBkikyjQH/lsqCy9t6tIY=
 github.com/wasilibs/nottinygc v0.4.0 h1:h1TJMihMC4neN6Zq+WKpLxgd9xCFMw7O9ETLwY2exJQ=
 github.com/wasilibs/nottinygc v0.4.0/go.mod h1:oDcIotskuYNMpqMF23l7Z8uzD4TC0WXHK8jetlB3HIo=
 golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -20,7 +20,7 @@ import (
 )
 
 var minGoVersion = "1.20"
-var tinygoMinorVersion = "0.29"
+var tinygoMinorVersion = "0.30"
 var addLicenseVersion = "04bfe4ee9ca5764577b029acc6a1957fd1997153" // https://github.com/google/addlicense
 var golangCILintVer = "v1.54.2"                                    // https://github.com/golangci/golangci-lint/releases
 var gosImportsVer = "v0.3.1"                                       // https://github.com/rinchsan/gosimports/releases/tag/v0.3.1


### PR DESCRIPTION
tinygo `0.30.0` is out and our tinygo version check is very strict. The update looks okay.
Updated also coraza-wasilibs that includes [go-re2 latest release](https://github.com/wasilibs/go-re2/releases/tag/v1.4.0).