### PR TITLE
chore: fixes Wasm path for EnvoyExample, removes detached

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,21 +72,6 @@ jobs:
       - name: Run unit tests
         run: go run mage.go coverage
 
-      - name: Check Envoy example is spinning up
-        run: |
-          ENVOY_CONTAINER_NAME="envoy-envoy-1"
-          go run mage.go runEnvoyExample &
-          TIMEOUT=5
-          while [ $TIMEOUT -gt 0 ]; do
-            exit_code=$(docker inspect -f '{{.State.ExitCode}}' $ENVOY_CONTAINER_NAME)
-            if [ $exit_code -ne 0 ]; then
-              echo "Envoy example failed to start"
-              exit 1
-            fi
-            sleep 1  # Wait for 1 second before checking again for up to TIMEOUT times
-            ((TIMEOUT--))
-          done
-
       - name: Run e2e tests
         shell: bash
         run: >

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,21 @@ jobs:
       - name: Run unit tests
         run: go run mage.go coverage
 
+      - name: Check Envoy example is spinning up
+        run: |
+          ENVOY_CONTAINER_NAME="envoy-envoy-1"
+          go run mage.go runEnvoyExample &
+          TIMEOUT=5
+          while [ $TIMEOUT -gt 0 ]; do
+            exit_code=$(docker inspect -f '{{.State.ExitCode}}' $ENVOY_CONTAINER_NAME)
+            if [ $exit_code -ne 0 ]; then
+              echo "Envoy example failed to start"
+              exit 1
+            fi
+            sleep 1  # Wait for 1 second before checking again for up to TIMEOUT times
+            ((TIMEOUT--))
+          done
+
       - name: Run e2e tests
         shell: bash
         run: >

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ FTW_INCLUDE=920410 go run mage.go ftw
 
 ## Example: Spinning up the coraza-wasm-filter for manual tests
 
-Once the filter is built, via the commands `mage runEnvoyExample`, `mage reloadEnvoyExample`, and `mage teardownEnvoyExample` you can spin up, test, and tear down the test environment. 
+Once the filter is built, via the commands `go run mage.go runEnvoyExample`, `go run mage.go reloadEnvoyExample`, and `go run mage.go teardownEnvoyExample` you can spin up, test, and tear down the test environment. 
 Envoy with the coraza-wasm filter will be reachable at `localhost:8080`. 
 The filter is configured with the CRS loaded working in Anomaly Scoring mode. 
 For details and locally tweaking the configuration refer to [@demo-conf](./wasmplugin/rules/coraza-demo.conf) and [@crs-setup-demo-conf](./wasmplugin/rules/crs-setup-demo.conf).

--- a/example/envoy/docker-compose.yml
+++ b/example/envoy/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - --log-path
       - /home/envoy/logs/envoy.log
     volumes:
-      - ../build:/build
+      - ../../build:/build
       - .:/conf
       - logs:/home/envoy/logs:rw
     ports:

--- a/example/envoy/docker-compose.yml
+++ b/example/envoy/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - --log-path
       - /home/envoy/logs/envoy.log
     volumes:
-      - ../../build:/build
+      - ../build:/build
       - .:/conf
       - logs:/home/envoy/logs:rw
     ports:

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -274,7 +274,7 @@ func Ftw() error {
 
 // RunEnvoyExample spins up the test environment of envoy, access at http://localhost:8080. Requires docker-compose.
 func RunEnvoyExample() error {
-	return sh.RunWithV(map[string]string{"ENVOY_IMAGE": os.Getenv("ENVOY_IMAGE")}, "docker-compose", "--file", "example/envoy/docker-compose.yml", "up", "-d", "envoy-logs")
+	return sh.RunWithV(map[string]string{"ENVOY_IMAGE": os.Getenv("ENVOY_IMAGE")}, "docker-compose", "--file", "example/envoy/docker-compose.yml", "up")
 }
 
 // TeardownEnvoyExample tears down the test environment of envoy. Requires docker-compose.


### PR DESCRIPTION
- https://github.com/corazawaf/coraza-proxy-wasm/pull/233 moved the envoy example into an inner folder, a small fix to the wasm path is needed to properly run the example.
   - A CI test might follow to check that the example correctly loads, but I didn't manage to make it work right now
- Address https://github.com/corazawaf/coraza-proxy-wasm/pull/222#discussion_r1291940544 (avoids `mage` commands in readme)
- Address https://github.com/corazawaf/coraza-proxy-wasm/pull/222#discussion_r1291940432 (removes running the example in detached mode by default. It should simplify the usage and reduce the number of commands to just one to have the example running with logs printed)