### PR TITLE
fix(ci): creation of release if it does not exists

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,7 +158,9 @@ jobs:
         if: matrix.multiphase_eval=='true' && github.event_name == 'push' && contains(github.ref, 'refs/tags/')
         run: |
           set +e
+          tag="${GITHUB_REF#refs/tags/}"
           if ! gh release view ${tag}; then
+            echo "Release ${tag} does not exist, creating..."
             ./.github/workflows/release_notes.sh ${tag} > release-notes.txt
             gh release create ${tag} --draft --notes-file release-notes.txt --title ${GITHUB_REF#refs/tags/}
           fi


### PR DESCRIPTION
Attempt to fix https://github.com/corazawaf/coraza-proxy-wasm/actions/runs/7002845798/job/19047393332. Pushing a tag should lead the CI to create a draft release with the artifact attached