### PR TITLE
chore: BodyLimit and Memorylimit to 131072

### DIFF
--- a/wasmplugin/rules/coraza.conf-recommended.conf
+++ b/wasmplugin/rules/coraza.conf-recommended.conf
@@ -43,9 +43,9 @@ SecRule REQUEST_HEADERS:Content-Type "^application/json" \
 #
 # Running as a Wasm plugin, we expect Limit equal to MemoryLimit: it would be prevented buffering request body to files anyways.
 
-SecRequestBodyLimit 13107200
+SecRequestBodyLimit 131072
 
-SecRequestBodyInMemoryLimit 13107200
+SecRequestBodyInMemoryLimit 131072
 
 # SecRequestBodyNoFilesLimit 131072
 


### PR DESCRIPTION
As per https://github.com/corazawaf/coraza-proxy-wasm/pull/243#issuecomment-1821320487, `BodyLimit` and `Memorylimit` values in `demo.conf` have been set to the lower value (`131072`), but not `coraza.conf-recommended.conf`. This PR address it. 