### PR TITLE
Add the context on Envoy requests to the audit logs

### DIFF
--- a/wasmplugin/auditlogger.go
+++ b/wasmplugin/auditlogger.go
@@ -1,0 +1,103 @@
+package wasmplugin
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+
+	ctypes "github.com/corazawaf/coraza/v3/types"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+)
+
+// Transaction context to store against a transaction ID
+type TxnContext struct {
+	envoyRequestId string
+}
+
+// Logger that includes context from the request in the audit logs and owns the final formatting
+type ContextualAuditLogger struct {
+	txnContextMap map[string]*TxnContext
+	lock          sync.Mutex
+}
+
+// Get the global audit logger that can be used across all requests
+func NewAppAuditLogger() *ContextualAuditLogger {
+	return &ContextualAuditLogger{
+		txnContextMap: make(map[string]*TxnContext),
+	}
+}
+
+// Register a transaction with the logger
+func (cal *ContextualAuditLogger) Register(txnId string, ctx *TxnContext) {
+	cal.lock.Lock()
+	defer cal.lock.Unlock()
+
+	cal.txnContextMap[txnId] = ctx
+}
+
+// Remove the transaction information from the context map
+func (cal *ContextualAuditLogger) Unregister(txnId string) {
+	cal.lock.Lock()
+	defer cal.lock.Unlock()
+
+	delete(cal.txnContextMap, txnId)
+}
+
+// Emit log on the given rule and add the txn context if available
+func (cal *ContextualAuditLogger) AuditLog(rule ctypes.MatchedRule) {
+	cal.lock.Lock()
+	defer cal.lock.Unlock()
+
+	txnId := rule.TransactionID()
+
+	var log *strings.Builder
+	if ctx, ok := cal.txnContextMap[txnId]; ok {
+		// If we have context, add it to the log
+		fmt.Fprintf(log, "[request-id %q] ", ctx.envoyRequestId)
+	}
+
+	logError(rule, log)
+}
+
+func logError(error ctypes.MatchedRule, log *strings.Builder) {
+	msg := error.ErrorLog()
+	fmt.Fprint(log, msg)
+	switch error.Rule().Severity() {
+	case ctypes.RuleSeverityEmergency:
+		proxywasm.LogCritical(msg)
+	case ctypes.RuleSeverityAlert:
+		proxywasm.LogCritical(msg)
+	case ctypes.RuleSeverityCritical:
+		proxywasm.LogCritical(msg)
+	case ctypes.RuleSeverityError:
+		proxywasm.LogError(msg)
+	case ctypes.RuleSeverityWarning:
+		proxywasm.LogWarn(msg)
+	case ctypes.RuleSeverityNotice:
+		proxywasm.LogInfo(msg)
+	case ctypes.RuleSeverityInfo:
+		proxywasm.LogInfo(msg)
+	case ctypes.RuleSeverityDebug:
+		proxywasm.LogDebug(msg)
+	}
+}
+
+const (
+	// This is the standard Envoy header for request IDs
+	envoyRequestIdHeader = "x-request-id"
+)
+
+// A convenience method to register the request information with the audit logger if available
+// on the request (else ignores). Must be called in the request context.
+func registerRequestContextWithLogger(auditLogger *ContextualAuditLogger, txnId string) {
+	if id, err := proxywasm.GetHttpRequestHeader(envoyRequestIdHeader); err != nil {
+		auditLogger.Register(txnId, &TxnContext{
+			envoyRequestId: id,
+		})
+	}
+}
+
+// Remove context for the given transaction ID
+func removeRequestContextFromLogger(auditLogger *ContextualAuditLogger, txnId string) {
+	auditLogger.Unregister(txnId)
+}

--- a/wasmplugin/auditlogger.go
+++ b/wasmplugin/auditlogger.go
@@ -24,6 +24,7 @@ type ContextualAuditLogger struct {
 func NewAppAuditLogger() *ContextualAuditLogger {
 	return &ContextualAuditLogger{
 		txnContextMap: make(map[string]*TxnContext),
+		lock:          sync.Mutex{},
 	}
 }
 

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -12,10 +12,11 @@ import (
 
 // pluginConfiguration is a type to represent an example configuration for this wasm plugin.
 type pluginConfiguration struct {
-	directivesMap          DirectivesMap
-	metricLabels           map[string]string
-	defaultDirectives      string
-	perAuthorityDirectives map[string]string
+	directivesMap               DirectivesMap
+	metricLabels                map[string]string
+	defaultDirectives           string
+	perAuthorityDirectives      map[string]string
+	includeRequestIdInAuditLogs bool
 }
 
 type DirectivesMap map[string][]string
@@ -33,6 +34,11 @@ func parsePluginConfiguration(data []byte, infoLogger func(string)) (pluginConfi
 	}
 
 	jsonData := gjson.ParseBytes(data)
+	includeReqId := jsonData.Get("include_request_id_in_audit_logs")
+	if includeReqId.Exists() && includeReqId.IsBool() && includeReqId.Bool() {
+		config.includeRequestIdInAuditLogs = true
+	}
+
 	config.directivesMap = make(DirectivesMap)
 	jsonData.Get("directives_map").ForEach(func(key, value gjson.Result) bool {
 		directiveName := key.String()


### PR DESCRIPTION
This is not yet fully baked and I am here to get feedback on various choices. The motivation here is to bring a traceability between the Coraza audit logs and the envoy request logs by including the `x-request-id` header value in the audit logs.

This won't affect any of the existing usage as this inclusion is controlled by the `include_request_id_in_audit_logs` configuration.

I am looking for feedback over:
1. A broad need for this traceability vs just my use case (in which case a fork might suffice)
2. The configuration `include_request_id_in_audit_logs` vs something broader like include a list of request headers with given labels.
3. Implementation.

**I understand this lacks unit tests and the code could be cleaner but I am waiting for a general agreement over the approach before committing the time.**

Thanks all!