### PR TITLE
ci: removes multiplatform build 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,6 @@ jobs:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta-busybox.outputs.tags }}
-          platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta-busybox.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
It might be the cause of failing CI https://github.com/corazawaf/coraza-proxy-wasm/actions/runs/8526197643/job/23365692437

Attempt to fix: https://github.com/corazawaf/coraza-proxy-wasm/pull/266