### PR TITLE
fix: removes deprecated docker-compose in favour of docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ For details and locally tweaking the configuration refer to [@recommended-conf](
 
 In order to individually monitor envoy logs while performing requests, in another terminal you can run:
 
-- Envoy logs: `docker-compose -f ./example/envoy/docker-compose.yml logs -f envoy-logs`.
-- Critical wasm (audit) logs: `docker-compose -f ./example/envoy/docker-compose.yml logs -f wasm-logs`
+- Envoy logs: `docker compose -f ./example/envoy/docker-compose.yml logs -f envoy-logs`.
+- Critical wasm (audit) logs: `docker compose -f ./example/envoy/docker-compose.yml logs -f wasm-logs`
 
 The Envoy example comes also with a Grafana dashboard that can be accessed at `localhost:3000` (admin/admin) in order to monitor the memory consumption.
 

--- a/magefiles/loadtest.go
+++ b/magefiles/loadtest.go
@@ -29,14 +29,14 @@ func LoadTest() error {
 }
 
 func doLoadTest(conf string, payloadSize int, threads int) error {
-	if err := sh.RunV("docker-compose", "--file", "ftw/docker-compose.yml", "build", "--pull"); err != nil {
+	if err := sh.RunV("docker", "compose", "--file", "ftw/docker-compose.yml", "build", "--pull"); err != nil {
 		return err
 	}
 	defer func() {
-		_ = sh.RunV("docker-compose", "--file", "ftw/docker-compose.yml", "kill")
-		_ = sh.RunV("docker-compose", "--file", "ftw/docker-compose.yml", "down", "-v")
+		_ = sh.RunV("docker", "compose", "--file", "ftw/docker-compose.yml", "kill")
+		_ = sh.RunV("docker", "compose", "--file", "ftw/docker-compose.yml", "down", "-v")
 	}()
-	if err := sh.RunWithV(map[string]string{"ENVOY_CONFIG": fmt.Sprintf("/conf/%s", conf)}, "docker-compose",
+	if err := sh.RunWithV(map[string]string{"ENVOY_CONFIG": fmt.Sprintf("/conf/%s", conf)}, "docker", "compose",
 		"--file", "ftw/docker-compose.yml", "run", "--service-ports", "--rm", "-d", "envoy"); err != nil {
 		return err
 	}

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -223,14 +223,14 @@ func Build() error {
 	return patchWasm(filepath.Join("build", "mainraw.wasm"), filepath.Join("build", "main.wasm"), initialPages)
 }
 
-// E2e runs e2e tests with a built plugin against the example deployment. Requires docker-compose.
+// E2e runs e2e tests with a built plugin against the example deployment. Requires docker.
 func E2e() error {
 	var err error
-	if err = sh.RunV("docker-compose", "--file", "e2e/docker-compose.yml", "up", "-d", "envoy"); err != nil {
+	if err = sh.RunV("docker", "compose", "--file", "e2e/docker-compose.yml", "up", "-d", "envoy"); err != nil {
 		return err
 	}
 	defer func() {
-		_ = sh.RunV("docker-compose", "--file", "e2e/docker-compose.yml", "down", "-v")
+		_ = sh.RunV("docker", "compose", "--file", "e2e/docker-compose.yml", "down", "-v")
 	}()
 
 	envoyHost := os.Getenv("ENVOY_HOST")
@@ -245,18 +245,18 @@ func E2e() error {
 	// --nulled-body is needed because coraza-proxy-wasm returns a 200 OK with a nulled body when if the interruption happens after phase 3
 	if err = sh.RunV("go", "run", "github.com/corazawaf/coraza/v3/http/e2e/cmd/httpe2e@main", "--proxy-hostport",
 		"http://"+envoyHost, "--httpbin-hostport", "http://"+httpbinHost, "--nulled-body"); err != nil {
-		sh.RunV("docker-compose", "-f", "e2e/docker-compose.yml", "logs", "envoy")
+		sh.RunV("docker", "compose", "-f", "e2e/docker-compose.yml", "logs", "envoy")
 	}
 	return err
 }
 
-// Ftw runs ftw tests with a built plugin and Envoy. Requires docker-compose.
+// Ftw runs ftw tests with a built plugin and Envoy. Requires docker.
 func Ftw() error {
-	if err := sh.RunV("docker-compose", "--file", "ftw/docker-compose.yml", "build", "--pull"); err != nil {
+	if err := sh.RunV("docker", "compose", "--file", "ftw/docker-compose.yml", "build", "--pull"); err != nil {
 		return err
 	}
 	defer func() {
-		_ = sh.RunV("docker-compose", "--file", "ftw/docker-compose.yml", "down", "-v")
+		_ = sh.RunV("docker", "compose", "--file", "ftw/docker-compose.yml", "down", "-v")
 	}()
 	env := map[string]string{
 		"FTW_CLOUDMODE": os.Getenv("FTW_CLOUDMODE"),
@@ -270,22 +270,22 @@ func Ftw() error {
 	if os.Getenv("MEMSTATS") == "true" {
 		task = "ftw-memstats"
 	}
-	return sh.RunWithV(env, "docker-compose", "--file", "ftw/docker-compose.yml", "run", "--rm", task)
+	return sh.RunWithV(env, "docker", "compose", "--file", "ftw/docker-compose.yml", "run", "--rm", task)
 }
 
-// RunEnvoyExample spins up the test environment of envoy, access at http://localhost:8080. Requires docker-compose.
+// RunEnvoyExample spins up the test environment of envoy, access at http://localhost:8080. Requires docker.
 func RunEnvoyExample() error {
-	return sh.RunWithV(map[string]string{"ENVOY_IMAGE": os.Getenv("ENVOY_IMAGE")}, "docker-compose", "--file", "example/envoy/docker-compose.yml", "up")
+	return sh.RunWithV(map[string]string{"ENVOY_IMAGE": os.Getenv("ENVOY_IMAGE")}, "docker", "compose", "--file", "example/envoy/docker-compose.yml", "up")
 }
 
-// TeardownEnvoyExample tears down the test environment of envoy. Requires docker-compose.
+// TeardownEnvoyExample tears down the test environment of envoy. Requires docker.
 func TeardownEnvoyExample() error {
-	return sh.RunV("docker-compose", "--file", "example/envoy/docker-compose.yml", "down")
+	return sh.RunV("docker", "compose", "--file", "example/envoy/docker-compose.yml", "down")
 }
 
-// ReloadEnvoyExample reload the test environment (container) of envoy in case of envoy or wasm update. Requires docker-compose
+// ReloadEnvoyExample reload the test environment (container) of envoy in case of envoy or wasm update. Requires docker.
 func ReloadEnvoyExample() error {
-	return sh.RunV("docker-compose", "--file", "example/envoy/docker-compose.yml", "restart")
+	return sh.RunV("docker", "compose", "--file", "example/envoy/docker-compose.yml", "restart")
 }
 
 var Default = Build


### PR DESCRIPTION
Incidentally, we started seeing errors since https://github.com/corazawaf/coraza-proxy-wasm/pull/264 has been merged into `main`, but the root cause of CI problems comes from [`Docker Compose v1 will be removed from images on April, 1`](https://github.com/actions/runner-images/issues/9557). This PR moves from `docker-compose` to `docker compose`.