### PR TITLE
Allow empty path when HTTP method is CONNECT

### DIFF
--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -298,7 +298,7 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 	}
 
 	uri := ""
-	if method != http.MethodConnect { // CONNECT requests does not have a path
+	if method != http.MethodConnect { // CONNECT requests does not have a path, see https://httpwg.org/specs/rfc9110#CONNECT
 		// Note the pseudo-header :path includes the query.
 		// See https://httpwg.org/specs/rfc9113.html#rfc.section.8.3.1
 		uri, err = proxywasm.GetHttpRequestHeader(":path")

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -298,7 +298,10 @@ func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) t
 	}
 
 	uri := ""
-	if method != http.MethodConnect { // CONNECT requests does not have a path, see https://httpwg.org/specs/rfc9110#CONNECT
+	if method == http.MethodConnect { // CONNECT requests does not have a path, see https://httpwg.org/specs/rfc9110#CONNECT
+		// Populate uri with authority to build a proper request line
+		uri = authority
+	} else {
 		// Note the pseudo-header :path includes the query.
 		// See https://httpwg.org/specs/rfc9113.html#rfc.section.8.3.1
 		uri, err = proxywasm.GetHttpRequestHeader(":path")


### PR DESCRIPTION
Fix for issue #269 

Retrieves :method before :path to allow request without path if HTTP method is CONNECT.