### PR TITLE
New metric "Matched Rules"

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,4 +226,3 @@ waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="949
 # TYPE waf_filter_tx_total counter
 waf_filter_tx_total{} 11
 ```
-If the matched rules metric is active, more results will be shown in the previous command. 

--- a/README.md
+++ b/README.md
@@ -226,3 +226,4 @@ waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="949
 # TYPE waf_filter_tx_total counter
 waf_filter_tx_total{} 11
 ```
+If the matched rules metric is active, more results will be shown in the previous command. 

--- a/example/envoy/envoy-config.yaml
+++ b/example/envoy/envoy-config.yaml
@@ -3,9 +3,11 @@ stats_config:
     # Envoy extracts the first matching group as a value.
     # See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/metrics/v3/stats.proto#config-metrics-v3-statsconfig.
     - tag_name: phase
-      regex: "(_phase=([a-z_]+))"
+      regex: "(_phase=([a-z_]+)(?:_[a-z]+=|$))"
     - tag_name: rule_id
       regex: "(_ruleid=([0-9]+))"
+    - tag_name: transaction_id
+      regex: "(_transactionid=([a-zA-Z]+))"
     - tag_name: identifier
       regex: "(_identifier=([0-9a-z.:]+))"
     - tag_name: owner
@@ -79,6 +81,10 @@ static_resources:
                               "metric_labels": {
                                 "owner": "coraza",
                                 "identifier": "global"
+                              },
+                              "metric_flags": {
+                                "transaction_id": true,
+                                "export_matched_rules": true
                               },
                               "per_authority_directives":{
                                   "foo.example.com":"rs2",

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -14,6 +14,7 @@ import (
 type pluginConfiguration struct {
 	directivesMap          DirectivesMap
 	metricLabels           map[string]string
+	metricFlags            map[string]bool
 	defaultDirectives      string
 	perAuthorityDirectives map[string]string
 }
@@ -53,6 +54,12 @@ func parsePluginConfiguration(data []byte, infoLogger func(string)) (pluginConfi
 	config.metricLabels = make(map[string]string)
 	jsonData.Get("metric_labels").ForEach(func(key, value gjson.Result) bool {
 		config.metricLabels[key.String()] = value.String()
+		return true
+	})
+
+	config.metricFlags = make(map[string]bool)
+	jsonData.Get("metric_flags").ForEach(func(key, value gjson.Result) bool {
+		config.metricFlags[key.String()] = value.Bool()
 		return true
 	})
 

--- a/wasmplugin/metrics.go
+++ b/wasmplugin/metrics.go
@@ -50,3 +50,28 @@ func (m *wafMetrics) CountTXInterruption(phase string, ruleID int, metricLabelsK
 	fqn := sb.String()
 	m.incrementCounter(fqn)
 }
+
+func (m *wafMetrics) CountTXMatchedRules(phase string, ruleID int, transactionID string, metricLabelsKV []string, flagTransactionID bool) {
+	// Using the same logic as Count TXInterruption, but with this metric we want to:
+	// - record the number of times a rule was triggered in a specific phase of the specified transaction
+	// - record the phase where the rule was triggered
+	// - record the rule ID
+	// - record the transaction ID of matched rule. This is a unique identifier for the transaction.
+	// - record the labels that were used to identify the rule.
+	// This is metric is processed as:
+	// waf_filter_tx_matchedrules{phase="http_request_body",rule_id="100",transaction_id="SJNBEaBHutzVixMcVRi",identifier="global"}.
+	var sb strings.Builder
+
+	if flagTransactionID {
+		sb.WriteString(fmt.Sprintf("waf_filter.tx.matchedrules_ruleid=%d_transactionid=%s_phase=%s", ruleID, transactionID, phase))
+	} else {
+		sb.WriteString(fmt.Sprintf("waf_filter.tx.matchedrules_ruleid=%d_phase=%s", ruleID, phase))
+	}
+
+	for i := 0; i < len(metricLabelsKV); i += 2 {
+		sb.WriteString(fmt.Sprintf("_%s=%s", metricLabelsKV[i], metricLabelsKV[i+1]))
+	}
+
+	fqn := sb.String()
+	m.incrementCounter(fqn)
+}


### PR DESCRIPTION
This PR implements issue [#271](https://github.com/corazawaf/coraza-proxy-wasm/issues/271).
As explained in the issue, exporting a metric capable of telling us all rules evaluated by Coraza in blocked transactions is very helpful to troubleshooting the configuration of Coraza. 

To implement this idea the config.go, metrics.go, plugin.go and the envoy example (envoy-config.yaml) were modified. The config.go was altered to activate this new metric through envoy configuration:  `"metric_flags": { "transaction_id": true, "export_matched_rules": true}`. With the "export_matched_rules" := **true**, we enable the new metric and with the "transaction_id" := **true**, the _transaction_id_ tag will appear in the fields of the metric. Doing this configuration we should see some values as `waf_filter_tx_matchedrules{phase="http_request_headers",rule_id="900120",transaction_id="WiYtUsEPrAweKUjiwWP",identifier="global",owner="coraza"} 1` under the prometheus stats in localhost port 8082.

In this pull request there is a fix too. In the envoy-config.yaml the regex field of the "tag_name" phase was printing strange values in metrics, from README we have:

```sh
curl -s localhost:8082/stats/prometheus | grep waf_filter
```
```sh
# TYPE waf_filter_tx_interruptions counter
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="101",identifier="global",owner="coraza"} 1
waf_filter_tx_interruptions{phase="http_request_body_identifier",rule_id="102",identifier="global",owner="coraza"} 1
waf_filter_tx_interruptions{phase="http_response_headers_identifier",rule_id="103",identifier="global",owner="coraza"} 1
waf_filter_tx_interruptions{phase="http_response_body_identifier",rule_id="104",identifier="global",owner="coraza"} 1
waf_filter_tx_interruptions{phase="http_request_body_identifier",rule_id="949110",identifier="global",owner="coraza"} 1
waf_filter_tx_interruptions{phase="http_response_headers_identifier",rule_id="949110",identifier="global",owner="coraza"} 1
waf_filter_tx_interruptions{phase="http_request_headers_identifier",rule_id="949111",identifier="global",owner="coraza"} 1
# TYPE waf_filter_tx_total counter
waf_filter_tx_total{} 11
```
Highlighting the phase tag in, for example, "waf_filter_tx_interruptions{**phase="http_request_headers_identifier"**,rule_id="101",identifier="global",owner="coraza"} 1", we got **http_request_headers_identifier**, but it should be printing only **http_request_headers** without the _identifier. So the fix approach another way to do a regex to capture the http phases, now, it is logging just "http_request_headers" (or "http_request_body", etc.).

I'm open to feedback, reviews, improvements or other ways to implement this idea.
Thank you!