### PR TITLE
chore: updates to latest envoy images

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,11 +16,11 @@ env:
   TINYGO_VERSION: 0.30.0
   # Run e2e tests against latest two releases and latest dev
   ENVOY_IMAGES: >
+    envoyproxy/envoy:v1.30-latest
     envoyproxy/envoy:v1.29-latest
-    envoyproxy/envoy:v1.28-latest
     envoyproxy/envoy-dev:latest
-    istio/proxyv2:1.21.0
-    istio/proxyv2:1.20.4
+    istio/proxyv2:1.22.1
+    istio/proxyv2:1.21.3
 
 jobs:
   build:


### PR DESCRIPTION
Address https://github.com/corazawaf/coraza-proxy-wasm/pull/282#discussion_r1659641187. Step before updating to Coraza v3.2.1