### PR TITLE
feat(magefile): allow to customise interp timeout

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -216,7 +216,21 @@ func Build() error {
 		}
 	}
 
-	if err := sh.RunV("tinygo", "build", "-gc=custom", "-opt=2", "-o", filepath.Join("build", "mainraw.wasm"), "-scheduler=none", "-target=wasip1", buildTagArg); err != nil {
+	buildArgs := []string{
+		"build",
+		"-gc=custom",
+		"-opt=2",
+		"-o", filepath.Join("build", "mainraw.wasm"),
+		"-scheduler=none",
+		"-target=wasip1",
+		buildTagArg,
+	}
+
+	if interpTimeout, ok := os.LookupEnv("INTERP_TIMEOUT"); ok {
+		buildArgs = append(buildArgs, "-interp-timeout="+interpTimeout)
+	}
+
+	if err := sh.RunV("tinygo", buildArgs...); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The build process is failing after 3 minutes ([default tinygo inter timeout](https://github.com/tinygo-org/tinygo/blob/3e60eeb368f25f237a512e7553fd6d70f36dc74c/main.go#L1500)) when trying to build a filter with GeoIP pluging that has a city database embedded:
```
/app/geoip.go:15:6: interp: running for more than 3m0s, timing out (executed calls: 2)
%stackalloc = alloca i8, align 1, !dbg !46
traceback:
/app/geoip.go:15:6:
%stackalloc = alloca i8, align 1, !dbg !46
app:
call void @"main.init#1"(ptr undef), !dbg !44
Error: running "tinygo build -gc=custom -opt=2 -o build/mainraw.wasm -scheduler=none -target=wasip1 -tags='custommalloc nottinygc_envoy no_fs_access memoize_builders coraza.rule.multiphase_evaluation'" failed with exit code 1
```

This change will allow increasing the timeout so that builds that use the `go:embed` directive aren't failing.