### PR TITLE
fix: ci deprecated actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -87,7 +87,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
-          name: ftw-envoy-logs
+          name: ftw-envoy-logs-multiphase-${{ matrix.multiphase_eval }}
           path: build/ftw-envoy.log
 
       - name: Set up QEMU

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
       MULTIPHASE_EVAL: ${{ matrix.multiphase_eval }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:  # Ensure release_notes.sh can see prior commits
           fetch-depth: 0
 
@@ -84,7 +84,7 @@ jobs:
       - name: Run regression tests (ftw)
         run: go run mage.go ftw
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
           name: ftw-envoy-logs

--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -22,7 +22,7 @@ jobs:
       MULTIPHASE_EVAL: ${{ matrix.multiphase_eval }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
See https://github.com/corazawaf/coraza-proxy-wasm/pull/301 ci run.

> actions/upload-artifact@v3 is scheduled for deprecation on November 30, 2024. [Learn more.](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) Similarly, v1/v2 are scheduled for deprecation on June 30, 2024. Please update your workflow to use v4 of the artifact actions. This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers.