### PR TITLE
bump tinygo to `0.36.0`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,15 +13,16 @@ on:
 
 env:
   GO_VERSION: '1.23'
-  TINYGO_VERSION: 0.34.0
+  TINYGO_VERSION: 0.36.0
   # Run e2e tests against latest two releases and latest dev
   ENVOY_IMAGES: >
+    envoyproxy/envoy:v1.34-latest
     envoyproxy/envoy:v1.33-latest
     envoyproxy/envoy:v1.32-latest
     envoyproxy/envoy-dev:latest
-    istio/proxyv2:1.25.0
-    istio/proxyv2:1.24.3
-    istio/proxyv2:1.23.5
+    istio/proxyv2:1.25.2
+    istio/proxyv2:1.24.5
+    istio/proxyv2:1.23.6
 
 jobs:
   build:

--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   GO_VERSION: '1.23'
-  TINYGO_VERSION: 0.34.0
+  TINYGO_VERSION: 0.36.0
 
 jobs:
   test:

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -222,7 +222,8 @@ func Build() error {
 		"-opt=2",
 		"-o", filepath.Join("build", "mainraw.wasm"),
 		"-scheduler=none",
-		"-target=wasip1",
+		"-target=wasi",
+		"-buildmode=wasi-legacy",
 		buildTagArg,
 	}
 


### PR DESCRIPTION
See https://github.com/tinygo-org/tinygo/issues/4726 and https://github.com/tinygo-org/tinygo/pull/4734. Closes https://github.com/corazawaf/coraza-proxy-wasm/pull/298