### PR TITLE
chore(ci): harden GHA workflows with least-privilege permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,11 @@ on:
       - "**/*.md"
       - "LICENSE"
   pull_request:
+    branches:
+      - main
   workflow_dispatch:
+
+permissions: {}
 
 env:
   GO_VERSION: '1.23'
@@ -38,12 +42,12 @@ jobs:
       MULTIPHASE_EVAL: ${{ matrix.multiphase_eval }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:  # Ensure release_notes.sh can see prior commits
           fetch-depth: 0
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88eb36e1604f7633e # v3
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -57,7 +61,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache TinyGo build
-        uses: actions/cache@v3
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v3
         with:
           path: |
             ~/.cache/tinygo
@@ -85,23 +89,23 @@ jobs:
       - name: Run regression tests (ftw)
         run: go run mage.go ftw
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         if: success() || failure()
         with:
           name: ftw-envoy-logs-multiphase-${{ matrix.multiphase_eval }}
           path: build/ftw-envoy.log
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
         if: ${{ matrix.multiphase_eval=='true' }}
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Docker meta
         if: ${{ matrix.multiphase_eval=='true' }}
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -114,7 +118,7 @@ jobs:
       - name: Docker meta busybox
         if: ${{ matrix.multiphase_eval=='true' }}
         id: meta-busybox
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -128,7 +132,7 @@ jobs:
 
       - name: Login to GHCR
         if: ${{ matrix.multiphase_eval=='true' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -136,7 +140,7 @@ jobs:
 
       - name: Build and push busybox based image
         if: ${{ matrix.multiphase_eval=='true' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -150,7 +154,7 @@ jobs:
 
       - name: Build and push
         if: ${{ matrix.multiphase_eval=='true' }}
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -172,7 +176,6 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
 
       - name: Push build artifact to release
         # Triggered only on tag creation

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -3,6 +3,8 @@ on:
   schedule:
     - cron: "30 1 * * *"
 
+permissions: {}
+
 jobs:
   close-issues:
     runs-on: ubuntu-latest
@@ -10,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v3
+      - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -7,6 +7,8 @@ on:
   schedule:
     - cron: "0 4 * * *"
 
+permissions: {}
+
 env:
   GO_VERSION: '1.23'
   TINYGO_VERSION: 0.34.0
@@ -15,6 +17,8 @@ jobs:
   test:
     name: "Test (multiphase evaluation: ${{ matrix.multiphase_eval }})"
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     strategy:
       matrix:
         multiphase_eval: ["true","false"]
@@ -22,10 +26,10 @@ jobs:
       MULTIPHASE_EVAL: ${{ matrix.multiphase_eval }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
 
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88eb36e1604f7633e # v3
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
@@ -39,7 +43,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache TinyGo build
-        uses: actions/cache@v3
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v3
         with:
           path: |
             ~/.cache/tinygo


### PR DESCRIPTION
## Summary

Harden all GitHub Actions workflows with security best practices:

| Change | Files affected |
|--------|---------------|
| Add top-level `permissions: {}` (deny-all default) | `ci.yaml`, `close-issues.yml`, `nightly-coraza-check.yaml` |
| Add job-level scoped permissions | `nightly-coraza-check.yaml` (added `contents: read`) |
| Pin all actions to full-length commit SHAs | All 3 workflow files |
| Add `branches: [main]` to `pull_request` trigger | `ci.yaml` |

### Actions pinned

| Action | Version | SHA |
|--------|---------|-----|
| `actions/checkout` | v4 | `11bd71901bbe5b1630ceea73d27597364c9af683` |
| `actions/setup-go` | v3 | `0aaccfd150d50ccaeb58ebd88eb36e1604f7633e` |
| `actions/cache` | v3 | `1bd1e32a3bdc45362d1e726936510720a7c30a57` |
| `actions/upload-artifact` | v4 | `4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1` |
| `actions/stale` | v3 | `98ed4cb500039dbcccf4bd9bedada4d0187f2757` |
| `docker/setup-qemu-action` | v3 | `c7c53464625b32c7a7e944ae62b3e17d2b600130` |
| `docker/setup-buildx-action` | v3 | `8d2750c68a42422c14e847fe6c8ac0403b4cbd6f` |
| `docker/metadata-action` | v4 | `818d4b7b91585d195f67373fd9cb0332e31a7175` |
| `docker/login-action` | v2 | `465a07811f14bebb1938fbed4728c6a1ff8901fc` |
| `docker/build-push-action` | v5 | `ca052bb54ab0790a636c9b5f226502c73d547a25` |