### PR TITLE
feat: configurable WAF blocking page via JSON config, supports {status_code} and {tx_id} placeholders

### DIFF
--- a/example/envoy/envoy-config.yaml
+++ b/example/envoy/envoy-config.yaml
@@ -83,7 +83,8 @@ static_resources:
                               "per_authority_directives":{
                                   "foo.example.com":"rs2",
                                   "bar.example.com":"rs2"
-                              }
+                              },
+                              "blocking_page": "<!DOCTYPE html>\n<html><head><meta charset=\"utf-8\"><title>{status_code} Blocked</title>\n<style>body{font-family:sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#f5f5f5}div{text-align:center}h1{font-size:4rem;margin:0;color:#c5221f}p{color:#555}code{background:#eee;padding:2px 6px;border-radius:3px}</style>\n</head><body><div><h1>{status_code}</h1><p>Request blocked by WAF</p><p><code>{tx_id}</code></p></div></body></html>"
                             }
                         vm_config:
                           runtime: "envoy.wasm.runtime.v8"

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -16,6 +16,7 @@ type pluginConfiguration struct {
 	metricLabels           map[string]string
 	defaultDirectives      string
 	perAuthorityDirectives map[string]string
+	blockingPageTemplate   string
 }
 
 type DirectivesMap map[string][]string
@@ -93,6 +94,11 @@ func parsePluginConfiguration(data []byte, infoLogger func(string)) (pluginConfi
 			})
 			config.directivesMap["default"] = directive
 		}
+	}
+
+	blockingPage := jsonData.Get("blocking_page")
+	if blockingPage.Exists() {
+		config.blockingPageTemplate = blockingPage.String()
 	}
 
 	return config, nil

--- a/wasmplugin/config_test.go
+++ b/wasmplugin/config_test.go
@@ -226,6 +226,47 @@ func TestParsePluginConfiguration(t *testing.T) {
 				perAuthorityDirectives: map[string]string{},
 			},
 		},
+		{
+			name: "with blocking page template",
+			config: `
+			{
+				"directives_map": {
+					"default": ["SecRuleEngine On"]
+				},
+				"default_directives": "default",
+				"blocking_page": "<html><body><h1>{status_code}</h1><p>Blocked: {tx_id}</p></body></html>"
+			}
+			`,
+			expectConfig: pluginConfiguration{
+				directivesMap: DirectivesMap{
+					"default": []string{"SecRuleEngine On"},
+				},
+				metricLabels:           map[string]string{},
+				defaultDirectives:      "default",
+				perAuthorityDirectives: map[string]string{},
+				blockingPageTemplate:   "<html><body><h1>{status_code}</h1><p>Blocked: {tx_id}</p></body></html>",
+			},
+		},
+		{
+			name: "without blocking page (defaults to empty)",
+			config: `
+			{
+				"directives_map": {
+					"default": ["SecRuleEngine On"]
+				},
+				"default_directives": "default"
+			}
+			`,
+			expectConfig: pluginConfiguration{
+				directivesMap: DirectivesMap{
+					"default": []string{"SecRuleEngine On"},
+				},
+				metricLabels:           map[string]string{},
+				defaultDirectives:      "default",
+				perAuthorityDirectives: map[string]string{},
+				blockingPageTemplate:   "",
+			},
+		},
 	}
 
 	for _, testCase := range testCases {
@@ -238,6 +279,7 @@ func TestParsePluginConfiguration(t *testing.T) {
 				assert.Equal(t, testCase.expectConfig.metricLabels, cfg.metricLabels)
 				assert.Equal(t, testCase.expectConfig.defaultDirectives, cfg.defaultDirectives)
 				assert.Equal(t, testCase.expectConfig.perAuthorityDirectives, cfg.perAuthorityDirectives)
+				assert.Equal(t, testCase.expectConfig.blockingPageTemplate, cfg.blockingPageTemplate)
 			}
 		})
 	}

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -78,9 +78,10 @@ type corazaPlugin struct {
 	// Embed the default plugin context here,
 	// so that we don't need to reimplement all the methods.
 	types.DefaultPluginContext
-	perAuthorityWAFs wafMap
-	metricLabelsKV   []string
-	metrics          *wafMetrics
+	perAuthorityWAFs     wafMap
+	metricLabelsKV       []string
+	metrics              *wafMetrics
+	blockingPageTemplate string
 }
 
 func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPluginStartStatus {
@@ -172,16 +173,18 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 		ctx.metricLabelsKV = append(ctx.metricLabelsKV, k, v)
 	}
 	ctx.metrics = NewWAFMetrics()
+	ctx.blockingPageTemplate = config.blockingPageTemplate
 
 	return types.OnPluginStartStatusOK
 }
 
 func (ctx *corazaPlugin) NewHttpContext(contextID uint32) types.HttpContext {
 	return &httpContext{
-		contextID:        contextID,
-		metrics:          ctx.metrics,
-		metricLabelsKV:   ctx.metricLabelsKV,
-		perAuthorityWAFs: ctx.perAuthorityWAFs,
+		contextID:            contextID,
+		metrics:              ctx.metrics,
+		metricLabelsKV:       ctx.metricLabelsKV,
+		perAuthorityWAFs:     ctx.perAuthorityWAFs,
+		blockingPageTemplate: ctx.blockingPageTemplate,
 	}
 }
 
@@ -214,6 +217,11 @@ const (
 	interruptionPhaseHttpResponseBody    = iota
 )
 
+// The "blocking_page" JSON config field accepts an HTML template with these placeholders:
+//   - {tx_id}       → transaction ID
+//   - {status_code} → HTTP status code
+// When not set, the original behavior is preserved (empty body, status code only).
+
 type httpContext struct {
 	// Embed the default http context here,
 	// so that we don't need to reimplement all the methods.
@@ -229,6 +237,7 @@ type httpContext struct {
 	interruptedAt         interruptionPhase
 	logger                debuglog.Logger
 	metricLabelsKV        []string
+	blockingPageTemplate  string
 }
 
 func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
@@ -542,11 +551,18 @@ func (ctx *httpContext) OnHttpResponseBody(bodySize int, endOfStream bool) types
 	defer logTime("OnHttpResponseBody", currentTime())
 
 	if ctx.interruptedAt.isInterrupted() {
+		// If the interruption was already handled in an earlier phase (request headers/body),
+		// we already sent a custom response via SendHttpResponse. In that case, we should NOT
+		// replace the body - just continue to avoid interfering with the already-sent response.
+		// The replaceResponseBodyWhenInterrupted is only for interruptions during response body phase.
+		if ctx.interruptedAt != interruptionPhaseHttpResponseBody {
+			ctx.logger.Debug().
+				Str("interruption_handled_phase", ctx.interruptedAt.String()).
+				Msg("Interruption already handled in earlier phase, skipping body replacement")
+			return types.ActionContinue
+		}
 		// At response body phase, proxy-wasm currently relies on emptying the response body as a way of
 		// interruption the response. See https://github.com/corazawaf/coraza-proxy-wasm/issues/26.
-		// If OnHttpResponseBody is called again and an interruption has already been raised, it means that
-		// we have to keep going with the sanitization of the response, emptying it.
-		// Sending the crafted HttpResponse with empty body, we don't expect to trigger OnHttpResponseBody
 		ctx.logger.Debug().
 			Str("interruption_handled_phase", ctx.interruptedAt.String()).
 			Msg("Response body interruption already handled, keeping replacing the body")
@@ -715,8 +731,23 @@ func (ctx *httpContext) handleInterruption(phase interruptionPhase, interruption
 	if statusCode == 0 {
 		statusCode = defaultInterruptionStatusCode
 	}
-	if err := proxywasm.SendHttpResponse(uint32(statusCode), nil, nil, noGRPCStream); err != nil {
-		panic(err)
+	// If a blocking page template is configured, send it with placeholder replacement.
+	// Otherwise, use the original behavior: empty body with status code only.
+	if ctx.blockingPageTemplate != "" {
+		headers := [][2]string{
+			{"Content-Type", "text/html; charset=utf-8"},
+		}
+		txID := ctx.tx.ID()
+		statusCodeStr := strconv.Itoa(statusCode)
+		blockingPage := bytes.ReplaceAll([]byte(ctx.blockingPageTemplate), []byte("{tx_id}"), []byte(txID))
+		blockingPage = bytes.ReplaceAll(blockingPage, []byte("{status_code}"), []byte(statusCodeStr))
+		if err := proxywasm.SendHttpResponse(uint32(statusCode), headers, blockingPage, noGRPCStream); err != nil {
+			panic(err)
+		}
+	} else {
+		if err := proxywasm.SendHttpResponse(uint32(statusCode), nil, nil, noGRPCStream); err != nil {
+			panic(err)
+		}
 	}
 
 	// SendHttpResponse must be followed by ActionPause in order to stop malicious content


### PR DESCRIPTION
### Summary

Add a `blocking_page` field to the plugin JSON configuration, allowing users to customize the HTML page returned when a request is blocked by WAF rules — without recompiling the WASM binary.

### Motivation

Currently, `handleInterruption` calls `SendHttpResponse(statusCode, nil, nil, ...)`, which returns an empty body with only the status code. This provides no context to end‑users about why their request was blocked. By supporting a configurable HTML template, operators can serve a branded or informative block page.

### Design

- **Configuration parsing:** `blocking_page` is read from the plugin JSON via `gjson` in `parsePluginConfiguration`.
- **Template placeholders:** `{status_code}` and `{tx_id}` are replaced at runtime with the actual HTTP status code and Coraza transaction ID.
- **Default behavior unchanged:** If `blocking_page` is not set or empty, the original `SendHttpResponse(statusCode, nil, nil, ...)` call is preserved.
- **Field propagation:** The field follows the existing pattern (e.g., `metricLabelsKV`) through `pluginConfiguration` → `corazaPlugin` → `httpContext`.

### Files changed

| File | Change |
|------|--------|
| `wasmplugin/config.go` | +6: `blockingPageTemplate` field |
| `wasmplugin/config_test.go` | +42: test cases for template rendering |
| `wasmplugin/plugin.go` | +55/-13: conditional `SendHttpResponse` logic |
| `example/envoy/envoy-config.yaml` | +2/-1: example `blocking_page` configuration |

### Key logic

In `handleInterruption`:

```go
if blockingPageTemplate != "" {
    headers = {Content-Type: text/html}
    body = template with {status_code}/{tx_id} replaced
    SendHttpResponse(code, headers, body)
} else {
    SendHttpResponse(code, nil, nil) // original behavior
}
```

### Why the `OnHttpResponseBody` change?

When an interruption occurs during the request headers or body phase, `SendHttpResponse` with a custom HTML body is dispatched immediately. Without an early return, later `OnHttpResponseBody` callbacks would invoke `replaceResponseBodyWhenInterrupted`, overwriting the already‑sent HTML body with null bytes. The guard `ctx.interruptedAt != interruptionPhaseHttpResponseBody` prevents this.

### Configuration example

```json
{
  "directives_map": { "default": ["SecRuleEngine On", "..."] },
  "default_directives": "default",
  "blocking_page": "<html><body><h1>{status_code}</h1><p>{tx_id}</p></body></html>"
}
```

### Testing

- `go test ./wasmplugin/ -run TestParsePluginConfiguration` — 14/14 PASS (2 new tests)
- Built with TinyGo 0.34.0 + Go 1.23.8, tested against Envoy 1.38.0
- Verified: normal requests → 200, blocked requests → 403 with rendered template

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a customizable blocking page response with `{status_code}` and `{tx_id}` placeholder substitution.
* **Bug Fixes**
  * Improved interruption handling to avoid overwriting the response body when the interruption was already handled in an earlier phase.
* **Tests**
  * Added test coverage for parsing the new `blocking_page` configuration and its default behavior.
* **Documentation**
  * Documented the new `blocking_page` configuration field and supported placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->