### PR TITLE
fix: don't call ProcessResponseBody before response headers were evaluated

### DIFF
--- a/lifecycle_streamdone_test.go
+++ b/lifecycle_streamdone_test.go
@@ -1,0 +1,52 @@
+// Copyright The OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/proxytest"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm/types"
+)
+
+// TestStreamDoneWithoutResponseHeaders reproduces the case where a stream ends
+// without the response-headers phase ever running (local replies, HTTP->HTTPS
+// redirects, upstream errors). In that situation OnHttpStreamDone must not flush
+// ProcessResponseBody, otherwise coraza rejects the out-of-order call with
+// "Skipping anomalous call to ProcessResponseBody. It has been called before
+// response headers evaluation", flooding the logs.
+func TestStreamDoneWithoutResponseHeaders(t *testing.T) {
+	vmTest(t, func(t *testing.T, vm types.VMContext) {
+		conf := `{"directives_map": {"default": ["SecRuleEngine On"]}, "default_directives": "default"}`
+		opt := proxytest.
+			NewEmulatorOption().
+			WithVMContext(vm).
+			WithPluginConfiguration([]byte(conf))
+
+		host, reset := proxytest.NewHostEmulator(opt)
+		defer reset()
+
+		require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
+
+		id := host.InitializeHttpContext()
+
+		// Only the request-headers phase runs; the stream then ends without any
+		// response-headers callback, as with a redirect/local-reply/error.
+		action := host.CallOnRequestHeaders(id, [][2]string{
+			{":path", "/"},
+			{":method", "GET"},
+			{":authority", "localhost"},
+		}, true)
+		require.Equal(t, types.ActionContinue, action)
+
+		// OnHttpStreamDone.
+		host.CompleteHttpContext(id)
+
+		logs := strings.Join(host.GetWarnLogs(), "\n")
+		require.NotContains(t, logs, "anomalous call to ProcessResponseBody",
+			"OnHttpStreamDone must not call ProcessResponseBody when the response headers phase never ran")
+	})
+}

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -218,17 +218,18 @@ type httpContext struct {
 	// Embed the default http context here,
 	// so that we don't need to reimplement all the methods.
 	types.DefaultHttpContext
-	contextID             uint32
-	perAuthorityWAFs      wafMap
-	tx                    ctypes.Transaction
-	httpProtocol          string
-	processedRequestBody  bool
-	processedResponseBody bool
-	bodyReadIndex         int
-	metrics               *wafMetrics
-	interruptedAt         interruptionPhase
-	logger                debuglog.Logger
-	metricLabelsKV        []string
+	contextID                uint32
+	perAuthorityWAFs         wafMap
+	tx                       ctypes.Transaction
+	httpProtocol             string
+	processedRequestBody     bool
+	processedResponseHeaders bool
+	processedResponseBody    bool
+	bodyReadIndex            int
+	metrics                  *wafMetrics
+	interruptedAt            interruptionPhase
+	logger                   debuglog.Logger
+	metricLabelsKV           []string
 }
 
 func (ctx *httpContext) OnHttpRequestHeaders(numHeaders int, endOfStream bool) types.Action {
@@ -531,6 +532,7 @@ func (ctx *httpContext) OnHttpResponseHeaders(numHeaders int, endOfStream bool) 
 	}
 
 	interruption := tx.ProcessResponseHeaders(code, ctx.httpProtocol)
+	ctx.processedResponseHeaders = true
 	if interruption != nil {
 		return ctx.handleInterruption(interruptionPhaseHttpResponseHeaders, interruption)
 	}
@@ -665,7 +667,10 @@ func (ctx *httpContext) OnHttpStreamDone() {
 			// Responses without body won't call OnHttpResponseBody, but there are rules in the response body
 			// phase that still need to be executed. If they haven't been executed yet, and there has not been a previous
 			// interruption, now is the time.
-			if !ctx.processedResponseBody {
+			// Only flush when the response headers phase actually ran: streams that ended without it (local
+			// replies, redirects, upstream errors) would otherwise trigger ProcessResponseBody out of order,
+			// which coraza rejects with "anomalous call to ProcessResponseBody ... before response headers evaluation".
+			if !ctx.processedResponseBody && ctx.processedResponseHeaders {
 				ctx.logger.Info().Msg("Running ProcessResponseBody in OnHttpStreamDone, triggered actions will not be enforced. Further logs are for detection only purposes")
 				ctx.processedResponseBody = true
 				_, err := tx.ProcessResponseBody()


### PR DESCRIPTION
OnHttpStreamDone flushes ProcessResponseBody so that phase 4 rules run for responses that have no body. It did so unconditionally, but for streams that end before the response headers phase runs -- local replies, HTTP->HTTPS redirects, upstream errors, or requests aborted earlier in the chain -- this produces an out-of-order call that coraza rejects and logs at WARN for every such stream:

    Skipping anomalous call to ProcessResponseBody. It has been called before
    response headers evaluation

Track whether the response headers phase has run (processedResponseHeaders) and only flush ProcessResponseBody at stream end when it has. coraza no-ops the call in that state anyway, so no inspection is lost -- this only removes the log noise.

Adds a regression test covering a stream that completes after the request headers phase without any response headers callback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an out-of-order response-body processing warning when an HTTP stream ends before the response-headers phase runs, improving lifecycle reliability.

* **Tests**
  * Added a regression test covering stream completion without response-headers processing to ensure the warning does not reappear.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->