### PR TITLE
feat: add JSON rule log format via plugin config

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -857,6 +858,57 @@ func TestEmptyBody(t *testing.T) {
 			})
 		})
 	}
+}
+
+func TestLogErrorJSONFormat(t *testing.T) {
+	reqHdrs := [][2]string{
+		{":path", "/hello"},
+		{":method", "GET"},
+		{":authority", "localhost"},
+		{"X-CRS-Test", "for the win!"},
+	}
+
+	vmTest(t, func(t *testing.T, vm types.VMContext) {
+		conf := `{
+			"rule_log_format": "json",
+			"directives_map": {
+				"default": [
+					"SecRule REQUEST_HEADERS:X-CRS-Test \"@rx ^.*$\" \"id:999999,phase:1,log,severity:4,msg:'%{MATCHED_VAR}',pass,t:none\""
+				]
+			},
+			"default_directives": "default"
+		}`
+
+		opt := proxytest.
+			NewEmulatorOption().
+			WithVMContext(vm).
+			WithPluginConfiguration([]byte(strings.TrimSpace(conf)))
+
+		host, reset := proxytest.NewHostEmulator(opt)
+		defer reset()
+
+		require.Equal(t, types.OnPluginStartStatusOK, host.StartPlugin())
+
+		id := host.InitializeHttpContext()
+		action := host.CallOnRequestHeaders(id, reqHdrs, false)
+		require.Equal(t, types.ActionContinue, action)
+
+		logs := strings.Join(host.GetWarnLogs(), "\n")
+		require.NotContains(t, logs, "[client ")
+		require.Contains(t, logs, `"type":"coraza_rule_match"`)
+		require.Contains(t, logs, `"id":999999`)
+		require.Contains(t, logs, "for the win!")
+
+		var entry struct {
+			Type string `json:"type"`
+			Rule struct {
+				ID int `json:"id"`
+			} `json:"rule"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(logs), &entry))
+		require.Equal(t, "coraza_rule_match", entry.Type)
+		require.Equal(t, 999999, entry.Rule.ID)
+	})
 }
 
 func TestLogError(t *testing.T) {

--- a/wasmplugin/config.go
+++ b/wasmplugin/config.go
@@ -16,12 +16,15 @@ type pluginConfiguration struct {
 	metricLabels           map[string]string
 	defaultDirectives      string
 	perAuthorityDirectives map[string]string
+	ruleLogFormat          ruleLogFormat
 }
 
 type DirectivesMap map[string][]string
 
 func parsePluginConfiguration(data []byte, infoLogger func(string)) (pluginConfiguration, error) {
-	config := pluginConfiguration{}
+	config := pluginConfiguration{
+		ruleLogFormat: ruleLogFormatBracket,
+	}
 
 	data = bytes.TrimSpace(data)
 	if len(data) == 0 {
@@ -76,6 +79,15 @@ func parsePluginConfiguration(data []byte, infoLogger func(string)) (pluginConfi
 		if _, ok := config.directivesMap[directiveName]; !ok {
 			return config, fmt.Errorf("directive map not found for authority %s: %q", authority, directiveName)
 		}
+	}
+
+	ruleLogFormat := jsonData.Get("rule_log_format")
+	if ruleLogFormat.Exists() {
+		format, err := parseRuleLogFormat(ruleLogFormat.String())
+		if err != nil {
+			return config, err
+		}
+		config.ruleLogFormat = format
 	}
 
 	if len(config.directivesMap) == 0 {

--- a/wasmplugin/config_test.go
+++ b/wasmplugin/config_test.go
@@ -238,6 +238,11 @@ func TestParsePluginConfiguration(t *testing.T) {
 				assert.Equal(t, testCase.expectConfig.metricLabels, cfg.metricLabels)
 				assert.Equal(t, testCase.expectConfig.defaultDirectives, cfg.defaultDirectives)
 				assert.Equal(t, testCase.expectConfig.perAuthorityDirectives, cfg.perAuthorityDirectives)
+				if testCase.expectConfig.ruleLogFormat == "" {
+					assert.Equal(t, ruleLogFormatBracket, cfg.ruleLogFormat)
+				} else {
+					assert.Equal(t, testCase.expectConfig.ruleLogFormat, cfg.ruleLogFormat)
+				}
 			}
 		})
 	}

--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -124,7 +124,7 @@ func (ctx *corazaPlugin) OnPluginStart(pluginConfigurationSize int) types.OnPlug
 
 		// First we initialize our waf and our seclang parser
 		conf := coraza.NewWAFConfig().
-			WithErrorCallback(logError).
+			WithErrorCallback(newRuleLogCallback(config.ruleLogFormat)).
 			WithDebugLogger(debuglog.DefaultWithPrinterFactory(logPrinterFactory)).
 			// TODO(anuraaga): Make this configurable in plugin configuration.
 			// WithRequestBodyLimit(1024 * 1024 * 1024).
@@ -721,28 +721,6 @@ func (ctx *httpContext) handleInterruption(phase interruptionPhase, interruption
 
 	// SendHttpResponse must be followed by ActionPause in order to stop malicious content
 	return types.ActionPause
-}
-
-func logError(error ctypes.MatchedRule) {
-	msg := error.ErrorLog()
-	switch error.Rule().Severity() {
-	case ctypes.RuleSeverityEmergency:
-		proxywasm.LogCritical(msg)
-	case ctypes.RuleSeverityAlert:
-		proxywasm.LogCritical(msg)
-	case ctypes.RuleSeverityCritical:
-		proxywasm.LogCritical(msg)
-	case ctypes.RuleSeverityError:
-		proxywasm.LogError(msg)
-	case ctypes.RuleSeverityWarning:
-		proxywasm.LogWarn(msg)
-	case ctypes.RuleSeverityNotice:
-		proxywasm.LogInfo(msg)
-	case ctypes.RuleSeverityInfo:
-		proxywasm.LogInfo(msg)
-	case ctypes.RuleSeverityDebug:
-		proxywasm.LogDebug(msg)
-	}
 }
 
 // retrieveAddressInfo retrieves address properties from the proxy

--- a/wasmplugin/rule_log.go
+++ b/wasmplugin/rule_log.go
@@ -1,0 +1,173 @@
+// Copyright The OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package wasmplugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	ctypes "github.com/corazawaf/coraza/v3/types"
+	"github.com/tetratelabs/proxy-wasm-go-sdk/proxywasm"
+)
+
+const (
+	ruleLogType          = "coraza_rule_match"
+	maxRuleLogFieldBytes = 280
+)
+
+type ruleLogFormat string
+
+const (
+	ruleLogFormatBracket ruleLogFormat = "bracket"
+	ruleLogFormatJSON    ruleLogFormat = "json"
+)
+
+func parseRuleLogFormat(value string) (ruleLogFormat, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "bracket":
+		return ruleLogFormatBracket, nil
+	case "json":
+		return ruleLogFormatJSON, nil
+	default:
+		return "", fmt.Errorf("invalid rule_log_format %q: want bracket or json", value)
+	}
+}
+
+// newRuleLogCallback returns a Coraza error callback that logs matched rules
+// in the configured format at the severity mapped to proxy-wasm log levels.
+func newRuleLogCallback(format ruleLogFormat) func(ctypes.MatchedRule) {
+	return func(mr ctypes.MatchedRule) {
+		msg, err := formatRuleLogMessage(mr, format)
+		if err != nil {
+			proxywasm.LogWarnf("Failed to format rule log as %s, using bracket format: %v", format, err)
+			msg = mr.ErrorLog()
+		}
+
+		switch mr.Rule().Severity() {
+		case ctypes.RuleSeverityEmergency:
+			proxywasm.LogCritical(msg)
+		case ctypes.RuleSeverityAlert:
+			proxywasm.LogCritical(msg)
+		case ctypes.RuleSeverityCritical:
+			proxywasm.LogCritical(msg)
+		case ctypes.RuleSeverityError:
+			proxywasm.LogError(msg)
+		case ctypes.RuleSeverityWarning:
+			proxywasm.LogWarn(msg)
+		case ctypes.RuleSeverityNotice:
+			proxywasm.LogInfo(msg)
+		case ctypes.RuleSeverityInfo:
+			proxywasm.LogInfo(msg)
+		case ctypes.RuleSeverityDebug:
+			proxywasm.LogDebug(msg)
+		}
+	}
+}
+
+func formatRuleLogMessage(mr ctypes.MatchedRule, format ruleLogFormat) (string, error) {
+	if format == ruleLogFormatBracket {
+		return mr.ErrorLog(), nil
+	}
+
+	bts, err := json.Marshal(buildRuleLogEntry(mr))
+	if err != nil {
+		return "", err
+	}
+	return string(bts), nil
+}
+
+type ruleLogEntry struct {
+	Type         string         `json:"type"`
+	ClientIP     string         `json:"client_ip"`
+	ServerIP     string         `json:"server_ip"`
+	URI          string         `json:"uri"`
+	UniqueID     string         `json:"unique_id"`
+	Message      string         `json:"message"`
+	Data         string         `json:"data,omitempty"`
+	Disruptive   bool           `json:"disruptive"`
+	Phase        int            `json:"phase"`
+	Severity     int            `json:"severity"`
+	SeverityName string         `json:"severity_name"`
+	Rule         ruleLogRule    `json:"rule"`
+	Matches      []ruleLogMatch `json:"matches,omitempty"`
+}
+
+type ruleLogRule struct {
+	ID       int      `json:"id"`
+	File     string   `json:"file"`
+	Line     int      `json:"line"`
+	Rev      string   `json:"rev,omitempty"`
+	Ver      string   `json:"ver,omitempty"`
+	Maturity int      `json:"maturity,omitempty"`
+	Accuracy int      `json:"accuracy,omitempty"`
+	Operator string   `json:"operator,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
+}
+
+type ruleLogMatch struct {
+	Variable string `json:"variable,omitempty"`
+	Key      string `json:"key,omitempty"`
+	Value    string `json:"value,omitempty"`
+	Message  string `json:"message,omitempty"`
+	Data     string `json:"data,omitempty"`
+}
+
+func buildRuleLogEntry(mr ctypes.MatchedRule) ruleLogEntry {
+	rule := mr.Rule()
+	severity := rule.Severity()
+
+	entry := ruleLogEntry{
+		Type:         ruleLogType,
+		ClientIP:     mr.ClientIPAddress(),
+		ServerIP:     mr.ServerIPAddress(),
+		URI:          mr.URI(),
+		UniqueID:     mr.TransactionID(),
+		Message:      truncateRuleLogField(ruleMessage(mr)),
+		Data:         truncateRuleLogField(mr.Data()),
+		Disruptive:   mr.Disruptive(),
+		Phase:        int(rule.Phase()),
+		Severity:     severity.Int(),
+		SeverityName: severity.String(),
+		Rule: ruleLogRule{
+			ID:       rule.ID(),
+			File:     rule.File(),
+			Line:     rule.Line(),
+			Rev:      rule.Revision(),
+			Ver:      rule.Version(),
+			Maturity: rule.Maturity(),
+			Accuracy: rule.Accuracy(),
+			Operator: rule.Operator(),
+			Tags:     rule.Tags(),
+		},
+	}
+
+	for _, md := range mr.MatchedDatas() {
+		entry.Matches = append(entry.Matches, ruleLogMatch{
+			Variable: md.Variable().Name(),
+			Key:      md.Key(),
+			Value:    truncateRuleLogField(md.Value()),
+			Message:  truncateRuleLogField(md.Message()),
+			Data:     truncateRuleLogField(md.Data()),
+		})
+	}
+
+	return entry
+}
+
+func ruleMessage(mr ctypes.MatchedRule) string {
+	for _, md := range mr.MatchedDatas() {
+		if msg := md.Message(); msg != "" {
+			return msg
+		}
+	}
+	return mr.Message()
+}
+
+func truncateRuleLogField(value string) string {
+	if len(value) <= maxRuleLogFieldBytes {
+		return value
+	}
+	return value[:maxRuleLogFieldBytes]
+}

--- a/wasmplugin/rule_log_test.go
+++ b/wasmplugin/rule_log_test.go
@@ -1,0 +1,58 @@
+// Copyright The OWASP Coraza contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package wasmplugin
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseRuleLogFormat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in      string
+		want    ruleLogFormat
+		wantErr bool
+	}{
+		{in: "", want: ruleLogFormatBracket},
+		{in: "bracket", want: ruleLogFormatBracket},
+		{in: "BRACKET", want: ruleLogFormatBracket},
+		{in: "json", want: ruleLogFormatJSON},
+		{in: " JSON ", want: ruleLogFormatJSON},
+		{in: "yaml", wantErr: true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.in, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseRuleLogFormat(tc.in)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestParsePluginConfigurationRuleLogFormat(t *testing.T) {
+	cfg, err := parsePluginConfiguration([]byte(`{
+		"rule_log_format": "json",
+		"directives_map": {"default": ["SecRuleEngine On"]},
+		"default_directives": "default"
+	}`), func(string) {})
+	require.NoError(t, err)
+	require.Equal(t, ruleLogFormatJSON, cfg.ruleLogFormat)
+
+	_, err = parsePluginConfiguration([]byte(`{
+		"rule_log_format": "invalid",
+		"directives_map": {"default": ["SecRuleEngine On"]},
+		"default_directives": "default"
+	}`), func(string) {})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Add rule_log_format plugin option (`bracket|json`) so matched rules with log can emit structured JSON instead of ModSecurity-style bracket lines.

The default is `bracket` to be backward compatible


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable rule log formatting: users can now select between "bracket" or "json" format via the `rule_log_format` configuration option to suit their logging preferences.
  * JSON-formatted logs include structured rule metadata (source IPs, URI, message, severity, rule ID) for improved parsing and analysis.

* **Tests**
  * Added comprehensive test coverage for rule log format parsing and JSON output validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->