### PR TITLE
bump ghactions and stop using cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,11 +9,7 @@ on:
       - "**/*.md"
       - "LICENSE"
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
-
-permissions: {}
 
 env:
   GO_VERSION: '1.23'
@@ -42,15 +38,16 @@ jobs:
       MULTIPHASE_EVAL: ${{ matrix.multiphase_eval }}
     steps:
       - name: Check out code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:  # Ensure release_notes.sh can see prior commits
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          cache: false
 
       - name: Install TinyGo
         run: |
@@ -59,15 +56,6 @@ jobs:
           echo "$HOME/tinygo/bin" >> $GITHUB_PATH
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Cache TinyGo build
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v3
-        with:
-          path: |
-            ~/.cache/tinygo
-          key: ${{ runner.os }}-tinygo-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-tinygo-
 
       - name: Run code checks
         run: go run mage.go lint
@@ -89,23 +77,23 @@ jobs:
       - name: Run regression tests (ftw)
         run: go run mage.go ftw
 
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: success() || failure()
         with:
           name: ftw-envoy-logs-multiphase-${{ matrix.multiphase_eval }}
           path: build/ftw-envoy.log
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         if: ${{ matrix.multiphase_eval=='true' }}
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Docker meta
         if: ${{ matrix.multiphase_eval=='true' }}
         id: meta
-        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -118,7 +106,7 @@ jobs:
       - name: Docker meta busybox
         if: ${{ matrix.multiphase_eval=='true' }}
         id: meta-busybox
-        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ghcr.io/${{ github.repository }}
@@ -132,7 +120,7 @@ jobs:
 
       - name: Login to GHCR
         if: ${{ matrix.multiphase_eval=='true' }}
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -140,7 +128,7 @@ jobs:
 
       - name: Build and push busybox based image
         if: ${{ matrix.multiphase_eval=='true' }}
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -154,7 +142,7 @@ jobs:
 
       - name: Build and push
         if: ${{ matrix.multiphase_eval=='true' }}
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: ${{ github.event_name != 'pull_request' }}
@@ -176,6 +164,7 @@ jobs:
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
 
       - name: Push build artifact to release
         # Triggered only on tag creation

--- a/.github/workflows/close-issues.yml
+++ b/.github/workflows/close-issues.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@98ed4cb500039dbcccf4bd9bedada4d0187f2757 # v3
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14

--- a/.github/workflows/nightly-coraza-check.yaml
+++ b/.github/workflows/nightly-coraza-check.yaml
@@ -7,8 +7,6 @@ on:
   schedule:
     - cron: "0 4 * * *"
 
-permissions: {}
-
 env:
   GO_VERSION: '1.23'
   TINYGO_VERSION: 0.34.0
@@ -26,13 +24,15 @@ jobs:
       MULTIPHASE_EVAL: ${{ matrix.multiphase_eval }}
     steps:
       - name: Check out code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Install Go
-        uses: actions/setup-go@be3c94b385c4f180051c996d336f57a34c397495 # v3
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          cache: false
 
       - name: Install TinyGo
         run: |
@@ -42,15 +42,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache TinyGo build
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v3
-        with:
-          path: |
-            ~/.cache/tinygo
-          key: ${{ runner.os }}-tinygo-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-tinygo-
-
       - name: Get last commit of coraza
         id: coraza-latest-commit
         run: echo "value=$(gh api repos/corazawaf/coraza/commits/main -q .sha)" >> $GITHUB_OUTPUT
@@ -58,7 +49,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch last coraza version
-        run: go get -u github.com/corazawaf/coraza/v3@${{ steps.coraza-latest-commit.outputs.value }} && go mod tidy
+        run: go get -u github.com/corazawaf/coraza/v3@${CORAZA_COMMIT} && go mod tidy
+        env:
+          CORAZA_COMMIT: ${{ steps.coraza-latest-commit.outputs.value }}
 
       - name: Build WASM filter
         run: go run mage.go build


### PR DESCRIPTION
This PR bumps all the gh actions, and avoid using caches. caches can be prone to cache poisoning and is a hard find on gh action linter (zizmor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reliability by updating several build, test, and deployment tools to newer versions.
  * Reduced caching-related flakiness by adjusting Go build caching behavior and removing an outdated build cache step.
  * Updated nightly checks to pull the latest compatible dependency version more consistently.

* **Chores**
  * Refreshed workflow maintenance settings and cleanup automation.
  * Minor workflow cleanup and formatting updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->