### PR TITLE
add a default fallback case for undefined log level

### DIFF
--- a/wasmplugin/plugin.go
+++ b/wasmplugin/plugin.go
@@ -747,6 +747,11 @@ func logError(error ctypes.MatchedRule) {
 		proxywasm.LogInfo(msg)
 	case ctypes.RuleSeverityDebug:
 		proxywasm.LogDebug(msg)
+	default:
+		// Rules without an explicit severity action report it as unset rather than
+		// defaulting to RuleSeverityEmergency, so route them to critical explicitly
+		// instead of silently dropping the message.
+		proxywasm.LogCritical(msg)
 	}
 }
 


### PR DESCRIPTION
Preparing for a to-come bump to Coraza 3.7.0, I've faced that FTW tests were not passing correctly. During my investigation, I've found that this happened specifically when the Coraza module was bumped from 3.3.3 to 3.7.0.

With some help from Claude, the following situation was identified:

    In Coraza v3.3.3, Rule.Severity_ was just a zero-valued RuleSeverity field with no explicit default — Go's zero value is 0, which is numerically identical to RuleSeverityEmergency. So an unset-severity rule accidentally matched the RuleSeverityEmergency case and got logged via LogCritical.
    In Coraza v3.7.0, corazawaf.NewRule() (internal/corazawaf/rule.go:761-771) now explicitly initializes Severity_: types.RuleSeverityUnset (-1, added as a real enum value — types/severity.go:45-48), specifically to distinguish "no severity configured" from "severity 0/emergency" (matching ModSecurity semantics, per the comment in transaction.go).

This way, this PR adds a default fallback case on the logError function to enforce the same old behavior before Coraza bump, making LogCritical a default behavior for undefined logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for rules with unset or unknown severity levels by ensuring they are logged as critical errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->